### PR TITLE
chore: bump AGP to 9.0.0 to match media submodule

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/downloadManager/DownloadManagerOt.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/downloadManager/DownloadManagerOt.kt
@@ -47,7 +47,7 @@ class DownloadManagerOt(
                     if (!resp.isSuccessful) {
                         throw IllegalStateException("HTTP ${resp.code}")
                     }
-                    val body = resp.body
+                    val body = resp.body ?: throw IllegalStateException("Empty response body")
                     val total = body.contentLength()
                     var downloaded = 0L
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,9 @@ android.enableJetifier=true
 org.gradle.unsafe.configuration-cache=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
+# AGP 9.0 enables built-in Kotlin (android.builtInKotlin) by default, which
+# forbids the standalone org.jetbrains.kotlin.android plugin. The media
+# submodule (AGP 9.0.0) keeps the standalone plugin via these flags, so match
+# it here to avoid the larger built-in-Kotlin migration.
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "12.2.4"
 adaptive = "1.2.0"
-androidGradlePlugin = "8.13.2"
+androidGradlePlugin = "9.0.0"
 annotation = "1.9.1"
 kotlin = "2.3.0"
 coil = "3.3.0"


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

The `media` submodule was updated to AGP 9.0.0, which requires a single AGP version across the whole composite build (`AgpVersionCompatibilityRule`). This conflicted with OuterTune's AGP 8.13.2 and broke the build. This PR aligns AGP with `media` by bumping it to 9.0.0.

- `gradle/libs.versions.toml`: bump `androidGradlePlugin` from `8.13.2` to `9.0.0`.
- `gradle.properties`: add `android.builtInKotlin=false` and `android.newDsl=false`. AGP 9.0 ships built-in Kotlin and forbids the standalone `org.jetbrains.kotlin.android` plugin, so this follows `media`'s approach to keep the standalone Kotlin plugin and avoid the larger built-in Kotlin migration for now.
- `DownloadManagerOt`: okhttp 4.12's `Response.body` is nullable, so the non-null assumption is fixed with `?: throw`.

Verified by building `core/debug` and `core/release` (through minify/R8), and installing + launching the `core/debug` APK on an emulator (x86_64, SDK 36) to confirm it runs.

> Note: `full` flavor and signed release builds were not verified locally, as they fail on pre-existing environment prerequisites unrelated to this change (the FFmpeg shared libraries from `ffmpeg-android-maker` and the release keystore, respectively).

### Before/After Screenshots/Screen Record

No UI changes.

### Fixes the following issue(s)

- Fixes #

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)