### PR TITLE
fix(innertube): recover album tracks when videoId is only in the overlay

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/pages/AlbumPage.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/pages/AlbumPage.kt
@@ -81,7 +81,12 @@ data class AlbumPage(
 
         fun getSong(renderer: MusicResponsiveListItemRenderer, album: AlbumItem? = null): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                // Some albums return tracks without playlistItemData; the videoId then lives only
+                // in the overlay play button (or navigationEndpoint). Ported from ArchiveTune.
+                id = renderer.playlistItemData?.videoId
+                    ?: renderer.overlay?.musicItemThumbnailOverlayRenderer?.content?.musicPlayButtonRenderer?.playNavigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: return null,
                 title = PageHelper.extractRuns(renderer.flexColumns, "MUSIC_VIDEO").firstOrNull()?.text ?: return null,
                 artists = PageHelper.extractRuns(renderer.flexColumns, "MUSIC_PAGE_TYPE_ARTIST").map{
                     Artist(
@@ -91,16 +96,20 @@ data class AlbumPage(
                 },
                 album = album?.let {
                     Album(it.title, it.browseId)
-                } ?: renderer.flexColumns.getOrNull(2)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()?.let {
-                    Album(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId!!
-                    )
-                }!!,
+                } ?: renderer.flexColumns.getOrNull(2)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()?.let { run ->
+                    run.navigationEndpoint?.browseEndpoint?.browseId?.let { browseId ->
+                        Album(
+                            name = run.text,
+                            id = browseId
+                        )
+                    }
+                },
                 duration = renderer.fixedColumns?.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()
                     ?.text?.parseTime() ?: return null,
-                thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: album?.thumbnail!!,
+                thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl()
+                    ?: album?.thumbnail
+                    ?: return null,
                 explicit = renderer.badges?.find {
                     it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"
                 } != null


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Some albums fail to open: the detail screen stays empty (no tracks) and pressing play does nothing — no error and no toast. For the affected albums YouTube Music returns track renderers that have **no `playlistItemData`**, so `AlbumPage.getSong()` read a `null` videoId and dropped every track via `?: return null`. The album then loaded with 0 songs, which left the list empty and made the play button build an empty queue, so playback never started.

This PR makes the album track parser more robust:

- When `playlistItemData.videoId` is absent, fall back to the overlay play button (`overlay…musicPlayButtonRenderer.playNavigationEndpoint.watchEndpoint.videoId`) and then to `navigationEndpoint.watchEndpoint.videoId`.
- Soften the `album` and `thumbnail` non-null assertions (`!!`) to nullable fallbacks, so a single missing field drops only that field instead of throwing and discarding the whole track.

Verified on an emulator with a real album that previously failed: it now parses all 18 tracks and plays normally.

### Before/After Screenshots/Screen Record

- Before: opening the affected album shows an empty track list; the play button does nothing.
- After: all album tracks are listed and play as expected.

### Fixes the following issue(s)

- OuterTune/OuterTune#1240
- OuterTune/OuterTune#1234

### Relies on the following changes

- N/A

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)