### PR TITLE
chore: media サブモジュール更新と AGP/Gradle の引き上げ

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "12.2.4"
 adaptive = "1.2.0"
-androidGradlePlugin = "9.0.0"
+androidGradlePlugin = "9.2.1"
 annotation = "1.9.1"
 kotlin = "2.3.0"
 coil = "3.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 概要

`media` サブモジュール（`nift4/media`, `gramophone`）を最新化します。最新コミットは AGP を 9.2.1 に引き上げており、`media` は `includeBuild` による複合ビルド（composite build）として取り込まれているため、複合ビルドの要件を満たすよう親プロジェクト側のビルドツールも同時に引き上げます。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| `media` サブモジュール | `ac33220` | `3f52f92`（14 commits） |
| `androidGradlePlugin` | 9.0.0 | 9.2.1 |
| Gradle wrapper | 9.2.0 | 9.4.1 |

## 背景・理由

- `media` は `settings.gradle.kts` の `includeBuild("media")` で複合ビルドとして取り込まれ、media3 各モジュールがローカルプロジェクトへ dependency substitution されています。
- Gradle 複合ビルドは includeBuild 間で異なる AGP を許容しないため、`media` の AGP（9.2.1）に親側も合わせる必要があります（前例：`da5c26b0 chore: bump AGP to 9.0.0 to match media submodule`）。
- 複合ビルドでは Gradle 本体は親のラッパーが使われます。AGP 9.2 は Gradle 9.4.1 以上を要求するため、親ラッパーを 9.2.0 → 9.4.1 に更新します（[About AGP](https://developer.android.com/build/releases/about-agp)）。

## `media` 側の主な更新（14 commits）

androidx/media 由来のバグ修正が中心で、公開 API の破壊的変更は確認されませんでした。

- API 29 でビットマップサイズ起因の SysUI クラッシュ／再起動を回避（`SizeAvoidingBitmapLoader` 追加）
- Samsung 機種固有のバグ修正
- mka コンテナでの FLAC ビット深度検出
- Android Auto 接続監視（`AndroidAutoConnectionStateObserver`）の追加
- legacy セッション系・通知アイコンサイズ算出の各種修正

## 検証

- `./gradlew :app:assembleCoreDebug` → **BUILD SUCCESSFUL**（Gradle 9.4.1 / AGP 9.2.1、255 タスク実行、複合ビルド正常）
- 全 ABI の APK 生成を確認
- エミュレータ（API 36）へ debug APK を導入し、ローカル楽曲の再生を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
