### PR TITLE
chore: update media submodule and bump AGP/Gradle

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "12.2.4"
 adaptive = "1.2.0"
-androidGradlePlugin = "9.0.0"
+androidGradlePlugin = "9.2.1"
 annotation = "1.9.1"
 kotlin = "2.3.0"
 coil = "3.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Update the `media` submodule (`nift4/media`, `gramophone` branch) from `ac33220` to `3f52f92` (14 commits, all upstream androidx/media bug fixes — no breaking public API changes).
- Bump `androidGradlePlugin` 9.0.0 → 9.2.1. `media` is consumed as a Gradle composite build via `includeBuild`, and composite builds do not allow mismatched AGP versions across the included and consuming builds, so the parent AGP must match the submodule's new AGP (the latest `media` commit bumped it to 9.2.1).
- Bump the Gradle wrapper 9.2.0 → 9.4.1. In a composite build the parent's Gradle distribution is used for the whole build, and AGP 9.2 requires Gradle 9.4.1 or newer.
- Notable changes pulled in from `media`: API 29 bitmap-size SysUI crash/reboot workaround (`SizeAvoidingBitmapLoader`), a Samsung-specific fix, FLAC bit-depth detection in the mka container, and an Android Auto connection observer.
- Verified with `./gradlew :app:assembleCoreDebug` (BUILD SUCCESSFUL on Gradle 9.4.1 / AGP 9.2.1), and confirmed local playback on an emulator (API 36) with the debug APK.

### Before/After Screenshots/Screen Record

Not applicable — this PR makes no user-facing UI changes.

### Fixes the following issue(s)

- Fixes #

### Relies on the following changes

-


## Due diligence

- [ x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x ] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->