### PR TITLE
Bump dependencies (NewPipeExtractor v0.26.2, Ktor 3.5.0) and align build toolchain with media submodule

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "12.2.4"
 adaptive = "1.2.0"
-androidGradlePlugin = "9.0.0"
+androidGradlePlugin = "9.2.1"
 annotation = "1.9.1"
 kotlin = "2.3.0"
 coil = "3.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ material3 = "1.4.0"
 media3 = "1.8.0"
 room = "2.8.4"
 hilt = "2.57.2"
-ktor = "3.4.0"
+ktor = "3.5.0"
 ksp = "2.3.4"
 
 [libraries]
@@ -80,7 +80,7 @@ desugaring = { group = "com.android.tools", name = "desugar_jdk_libs", version =
 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 
-newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.25.1" }
+newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.26.2" }
 
 [plugins]
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Security-focused dependency refresh, plus the build toolchain alignment required to keep the build working.

- **NewPipeExtractor `v0.25.1` → `v0.26.2`**: pulls in updated transitive dependencies (protobuf-javalite 4.35.0, jsoup 1.22.2, gson 2.14.0). 
- **Ktor `3.4.0` → `3.5.0`**: brings OkHttp 5.3.2 transitively. No CVEs reported for Ktor in 2026.
- **Build toolchain alignment**: the `media` submodule was advanced (`ac33220e` → `3f52f92e`) to a revision that builds with AGP 9.2.1 and requires Gradle 9.4.1. In a composite build a single Gradle/AGP version must be shared, so the root wrapper is bumped to Gradle `9.4.1` and AGP `9.2.1` to match. Without this, `:app` fails to configure.

### Fixes the following issue(s)

- Fixes #

### Due diligence

- [ x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [ x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)