### PR TITLE
deps: bump Kotlin to 2.3.20 and KSP to 2.3.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ aboutLibraries = "12.2.4"
 adaptive = "1.2.0"
 androidGradlePlugin = "9.2.1"
 annotation = "1.9.1"
-kotlin = "2.3.0"
+kotlin = "2.3.20"
 coil = "3.3.0"
 compose = "1.10.2"
 lazycolumnscrollbar = "2.2.0"
@@ -13,7 +13,7 @@ media3 = "1.8.0"
 room = "2.8.4"
 hilt = "2.57.2"
 ktor = "3.5.0"
-ksp = "2.3.4"
+ksp = "2.3.9"
 
 [libraries]
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

dependency refresh (toolchain).

- Bump Kotlin `2.3.0` -> `2.3.20` (a 2.3-line tooling/bugfix release).
- Bump KSP `2.3.4` -> `2.3.9` to stay aligned with the Kotlin 2.3 language version.
- The Compose compiler and kotlin-serialization plugins follow automatically via `version.ref = kotlin`, so no separate version changes are needed.
- Kotlin `2.4.0` is still RC and is intentionally deferred to a later phase.

### Before/After Screenshots/Screen Record

N/A (no UI changes).

### Fixes the following issue(s)

- N/A

### Relies on the following changes

- N/A

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed