### PR TITLE
refactor: replace deprecated WindowWidthSizeClass with WindowSizeClass breakpoint API

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -106,7 +106,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import androidx.window.core.layout.WindowWidthSizeClass
+import androidx.window.core.layout.WindowSizeClass
 import com.dd3boh.outertune.constants.AppBarHeight
 import com.dd3boh.outertune.constants.DEFAULT_ENABLED_TABS
 import com.dd3boh.outertune.constants.DarkMode
@@ -269,7 +269,7 @@ class MainActivity : ComponentActivity() {
             val tabMode = this@MainActivity.tabMode()
             val useNavRail by remember {
                 derivedStateOf {
-                    windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED && !tabMode
+                    windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) && !tabMode
                 }
             }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

- Replace the deprecated `androidx.window.core.layout.WindowWidthSizeClass` with the recommended `WindowSizeClass` breakpoint API in `MainActivity`.
- The navigation-rail condition previously read `windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED`. It now uses `windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)`.
- `EXPANDED` is defined as a width of at least 840 dp, which is exactly `WIDTH_DP_EXPANDED_LOWER_BOUND`, so the threshold and runtime behavior are unchanged. This only removes the build-time deprecation warnings.
- No change to the minimum SDK; the replacement is in the same library API family.

### Before/After Screenshots/Screen Record

<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

- No visible UI change. The navigation rail still appears at the same width threshold (>= 840 dp).

### Fixes the following issue(s)

<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (ex: "Fixes #69". Note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

- Fixes #9

### Relies on the following changes

<!-- Tag any pull requests that are required before this can be merged.
Delete this if it doesn't apply to your PR. -->

- (none)

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [ x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->
