### PR TITLE
fix: handle playlists without a header in playlist()

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -334,21 +334,21 @@ object YouTube {
         PlaylistPage(
             playlist = PlaylistItem(
                 id = playlistId,
-                title = header?.title?.runs?.firstOrNull()?.text!!,
-                author = header.straplineTextOne?.runs?.firstOrNull()?.let {
+                title = header?.title?.runs?.firstOrNull()?.text ?: "",
+                author = header?.straplineTextOne?.runs?.firstOrNull()?.let {
                     Artist(
                         name = it.text,
                         id = it.navigationEndpoint?.browseEndpoint?.browseId
                     )
                 },
-                songCountText = header.secondSubtitle?.runs?.firstOrNull()?.text,
+                songCountText = header?.secondSubtitle?.runs?.firstOrNull()?.text,
                 thumbnail = response.background?.musicThumbnailRenderer?.getThumbnailUrl(),
-                playEndpoint = header.buttons.getOrNull(1)?.musicPlayButtonRenderer
+                playEndpoint = header?.buttons?.getOrNull(1)?.musicPlayButtonRenderer
                     ?.playNavigationEndpoint?.watchEndpoint,
-                shuffleEndpoint = header.buttons.getOrNull(2)?.menuRenderer?.items?.find {
+                shuffleEndpoint = header?.buttons?.getOrNull(2)?.menuRenderer?.items?.find {
                     it.menuNavigationItemRenderer?.icon?.iconType == "MUSIC_SHUFFLE"
                 }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
-                radioEndpoint = header.buttons.getOrNull(2)?.menuRenderer?.items?.find {
+                radioEndpoint = header?.buttons?.getOrNull(2)?.menuRenderer?.items?.find {
                     it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
                 }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
                 isEditable = editable
@@ -356,11 +356,11 @@ object YouTube {
             songs = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
                 ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getItems()?.mapNotNull {
                     PlaylistPage.fromMusicResponsiveListItemRenderer(it)
-                }!!,
-            songsContinuation = response.contents.twoColumnBrowseResultsRenderer.secondaryContents.sectionListRenderer
-                .contents.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation(),
-            continuation = response.contents.twoColumnBrowseResultsRenderer.secondaryContents.sectionListRenderer
-                .continuations?.getContinuation()
+                } ?: emptyList(),
+            songsContinuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
+                ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation(),
+            continuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
+                ?.continuations?.getContinuation()
         )
     }
 

--- a/innertube/src/test/java/com/zionhuang/innertube/YouTubeTest.kt
+++ b/innertube/src/test/java/com/zionhuang/innertube/YouTubeTest.kt
@@ -131,21 +131,26 @@ class YouTubeTest {
 
     @Test
     fun `Browse playlist`() = runBlocking {
-        // This playlist has 2900 songs
-        val playlistId = "PLtAw-mgfCzRwduBTjBHknz5U4_ZM4n6qm"
-        var count = 5
-        val playlistPage = YouTube.playlist(playlistId).getOrThrow()
-        var songs = playlistPage.songs
-        var continuation = playlistPage.songsContinuation
-        while (count > 0) {
-            songs.forEach {
-                println(it.id)
+        val playlistIds = listOf(
+            "PLtAw-mgfCzRwduBTjBHknz5U4_ZM4n6qm", // user-created playlist without a header
+            "RDCLAK5uy_l2pHac-aawJYLcesgTf67gaKU-B9ekk1o" // YouTube Music curated playlist with a header
+        )
+        for (playlistId in playlistIds) {
+            var count = 5
+            val playlistPage = YouTube.playlist(playlistId).getOrThrow()
+            var songs = playlistPage.songs
+            assertTrue(songs.isNotEmpty())
+            var continuation = playlistPage.songsContinuation
+            while (count > 0) {
+                songs.forEach {
+                    println(it.id)
+                }
+                if (continuation == null) break
+                val continuationPage = YouTube.playlistContinuation(continuation).getOrThrow()
+                songs = continuationPage.songs
+                continuation = continuationPage.continuation
+                count--
             }
-            if (continuation == null) break
-            val continuationPage = YouTube.playlistContinuation(continuation).getOrThrow()
-            songs = continuationPage.songs
-            continuation = continuationPage.continuation
-            count--
         }
     }
 


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Fixes a `NullPointerException` in `YouTube.playlist()` for playlists whose YouTube Music browse response contains no header renderer (e.g. certain public user-created `PL` playlists). `playlist()` dereferenced `title!!` and crashed. All header-dependent fields are now null-safe, the title falls back to an empty string, and the song list falls back to an empty list instead of a non-null assertion. This matches Metrolist's tolerant handling of header-less playlists.

The `Browse playlist` test is extended to cover both a header-less playlist (`PLtAw-…`) and a header-bearing YouTube Music playlist (`RDCLAK5uy_l2pHac-…`), asserting the song list is non-empty for each. Verified against the live API, with `Check 'browse' endpoint` re-run as a regression check.

### Before/After Screenshots/Screen Record

N/A (no UI changes)

### Fixes the following issue(s)

- Fixes #11

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)