### PR TITLE
fix: parse itemSectionRenderer in search summary

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -13,6 +13,7 @@ import com.zionhuang.innertube.models.SearchSuggestions
 import com.zionhuang.innertube.models.SongItem
 import com.zionhuang.innertube.models.WatchEndpoint
 import com.zionhuang.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
+import com.zionhuang.innertube.models.YTItem
 import com.zionhuang.innertube.models.YouTubeClient
 import com.zionhuang.innertube.models.YouTubeClient.Companion.IOS
 import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB
@@ -118,34 +119,72 @@ object YouTube {
 
     suspend fun searchSummary(query: String): Result<SearchSummaryPage> = runCatching {
         val response = innerTube.search(WEB_REMIX, query).body<SearchResponse>()
-        SearchSummaryPage(
-            summaries = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()?.tabRenderer?.content?.sectionListRenderer?.contents?.mapNotNull { it ->
-                if (it.musicCardShelfRenderer != null)
-                    SearchSummary(
-                        title = it.musicCardShelfRenderer.header?.musicCardShelfHeaderBasicRenderer?.title?.runs?.firstOrNull()?.text ?: "",
-                        items = listOfNotNull(SearchSummaryPage.fromMusicCardShelfRenderer(it.musicCardShelfRenderer))
-                            .plus(
-                                it.musicCardShelfRenderer.contents
-                                    ?.mapNotNull { it.musicResponsiveListItemRenderer }
-                                    ?.mapNotNull(SearchSummaryPage.Companion::fromMusicResponsiveListItemRenderer)
-                                    .orEmpty()
-                            )
-                            .distinctBy { it.id }
-                            .ifEmpty { null } ?: return@mapNotNull null
-                    )
-                else
-                    SearchSummary(
-                        title = it.musicShelfRenderer?.title?.runs?.firstOrNull()?.text ?: "",
-                        items = it.musicShelfRenderer?.contents?.getItems()
-                            ?.mapNotNull {
-                                SearchSummaryPage.fromMusicResponsiveListItemRenderer(it)
-                            }
-                            ?.distinctBy { it.id }
-                            ?.ifEmpty { null } ?: return@mapNotNull null
-                    )
-            }!!
-        )
+        val sections = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()
+            ?.tabRenderer?.content?.sectionListRenderer?.contents.orEmpty()
+
+        val summaries = mutableListOf<SearchSummary>()
+        for (content in sections) {
+            when {
+                content.musicCardShelfRenderer != null -> {
+                    val items = listOfNotNull(SearchSummaryPage.fromMusicCardShelfRenderer(content.musicCardShelfRenderer))
+                        .plus(
+                            content.musicCardShelfRenderer.contents
+                                ?.mapNotNull { it.musicResponsiveListItemRenderer }
+                                ?.mapNotNull(SearchSummaryPage.Companion::fromMusicResponsiveListItemRenderer)
+                                .orEmpty()
+                        )
+                        .distinctBy { it.id }
+                    if (items.isNotEmpty()) {
+                        summaries += SearchSummary(
+                            title = content.musicCardShelfRenderer.header?.musicCardShelfHeaderBasicRenderer?.title?.runs?.firstOrNull()?.text ?: "",
+                            items = items
+                        )
+                    }
+                }
+
+                content.musicShelfRenderer != null -> {
+                    val items = content.musicShelfRenderer.contents?.getItems()
+                        ?.mapNotNull { SearchSummaryPage.fromMusicResponsiveListItemRenderer(it) }
+                        ?.distinctBy { it.id }
+                        .orEmpty()
+                    if (items.isNotEmpty()) {
+                        summaries += SearchSummary(
+                            title = content.musicShelfRenderer.title?.runs?.firstOrNull()?.text ?: "",
+                            items = items
+                        )
+                    }
+                }
+
+                // Newer responses wrap individual results in itemSectionRenderer instead of
+                // titled shelves; group those items by type into separate summary sections.
+                content.itemSectionRenderer != null -> {
+                    val items = content.itemSectionRenderer.contents?.getItems()
+                        ?.mapNotNull { SearchSummaryPage.fromMusicResponsiveListItemRenderer(it) }
+                        .orEmpty()
+                    summaries += groupSearchItemsByType(items)
+                }
+            }
+        }
+
+        // Merge sections that share the same title (e.g. items split across many itemSectionRenderers).
+        val merged = summaries
+            .filter { it.items.isNotEmpty() }
+            .groupBy { it.title }
+            .map { (title, group) -> SearchSummary(title = title, items = group.flatMap { it.items }.distinctBy { it.id }) }
+
+        SearchSummaryPage(summaries = merged)
     }
+
+    private fun groupSearchItemsByType(items: List<YTItem>): List<SearchSummary> =
+        items.groupBy { item ->
+            when (item) {
+                is SongItem -> "Songs"
+                is AlbumItem -> "Albums"
+                is ArtistItem -> "Artists"
+                is PlaylistItem -> "Playlists"
+                else -> "Other"
+            }
+        }.map { (title, group) -> SearchSummary(title = title, items = group) }
 
     suspend fun search(query: String, filter: SearchFilter): Result<SearchResult> = runCatching {
         val response = innerTube.search(WEB_REMIX, query, filter.value).body<SearchResponse>()

--- a/innertube/src/main/java/com/zionhuang/innertube/models/ItemSectionRenderer.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/ItemSectionRenderer.kt
@@ -1,0 +1,12 @@
+package com.zionhuang.innertube.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Search summary responses now wrap individual results in [ItemSectionRenderer]s instead of
+ * grouping them into titled [MusicShelfRenderer] shelves.
+ */
+@Serializable
+data class ItemSectionRenderer(
+    val contents: List<MusicShelfRenderer.Content>?,
+)

--- a/innertube/src/main/java/com/zionhuang/innertube/models/SectionListRenderer.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/SectionListRenderer.kt
@@ -47,5 +47,6 @@ data class SectionListRenderer(
         val musicResponsiveHeaderRenderer: MusicResponsiveHeaderRenderer?,
         val musicEditablePlaylistDetailHeaderRenderer: MusicEditablePlaylistDetailHeaderRenderer?,
         val gridRenderer: GridRenderer?,
+        val itemSectionRenderer: ItemSectionRenderer?,
     )
 }

--- a/innertube/src/test/java/com/zionhuang/innertube/YouTubeTest.kt
+++ b/innertube/src/test/java/com/zionhuang/innertube/YouTubeTest.kt
@@ -49,17 +49,28 @@ class YouTubeTest {
         // Top result with radio link
         val searchAllTypeResult = youTube.searchSummary("musi").getOrThrow()
         assertTrue(searchAllTypeResult.summaries.size > 1)
-        for (filter in listOf(
-            FILTER_SONG,
-            FILTER_VIDEO,
-            FILTER_ALBUM,
-            FILTER_ARTIST,
-            FILTER_FEATURED_PLAYLIST,
-            FILTER_COMMUNITY_PLAYLIST
-        )) {
+
+        // An artist query covers songs, videos, albums, the artist itself,
+        // and user-created (community) playlists.
+        val filters = mapOf(
+            "song" to FILTER_SONG,
+            "video" to FILTER_VIDEO,
+            "album" to FILTER_ALBUM,
+            "artist" to FILTER_ARTIST,
+            "community playlist" to FILTER_COMMUNITY_PLAYLIST,
+        )
+        for ((name, filter) in filters) {
             val searchResult = youTube.search(SEARCH_QUERY, filter).getOrThrow()
-            assertTrue(searchResult.items.isNotEmpty())
+            assertTrue("no items returned for filter: $name", searchResult.items.isNotEmpty())
         }
+    }
+
+    @Test
+    fun `Check 'featured playlist' search`() = runBlocking {
+        // Featured (YouTube Music curated) playlists exist for moods/genres,
+        // not for artist names, so a mood query is used here.
+        val searchResult = youTube.search("relax", FILTER_FEATURED_PLAYLIST).getOrThrow()
+        assertTrue(searchResult.items.isNotEmpty())
     }
 
     @Test


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

YouTube Music now wraps individual search-summary results in `itemSectionRenderer` sections instead of titled `musicShelfRenderer` shelves. As a result `searchSummary()` only returned the top-result card and dropped the rest, so the search summary UI showed a single section.

- Handle `itemSectionRenderer` in `searchSummary()`, grouping its items by type (Songs/Albums/Artists/Playlists) and merging sections that share a title.
- Add an `ItemSectionRenderer` model and wire it into `SectionListRenderer`.
- Test: split the artist-query search test from featured-playlist search. Featured (YouTube Music curated) playlists do not exist for artist names, so they are now verified with a mood query in a dedicated test.
- Test: add a per-filter failure message so a failing filter is identifiable.

Verified against the live API: `Check 'search' endpoint` and `Check 'featured playlist' search` pass.

### Before/After Screenshots/Screen Record

N/A (no UI layout changes; the search summary now shows multiple grouped sections again instead of only the top result)

### Fixes the following issue(s)

- Fixes #11

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)