### PR TITLE
fix: improve LrcLib matching and reduce lyrics display latency

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/lyrics/LyricsHelper.kt
+++ b/app/src/main/java/com/dd3boh/outertune/lyrics/LyricsHelper.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.lyrics
 
 import android.content.Context
+import android.util.Log
 import android.util.LruCache
 import com.dd3boh.outertune.constants.LyricSourcePrefKey
 import com.dd3boh.outertune.constants.LyricTrimKey
@@ -24,7 +25,7 @@ class LyricsHelper @Inject constructor(
     val database: MusicDatabase
 ) {
     private val lyricsProviders =
-        listOf(YouTubeSubtitleLyricsProvider, LrcLibLyricsProvider, KuGouLyricsProvider, YouTubeLyricsProvider)
+        listOf(LrcLibLyricsProvider, KuGouLyricsProvider, YouTubeLyricsProvider, YouTubeSubtitleLyricsProvider)
     private val cache = LruCache<String, List<LyricsResult>>(MAX_CACHE_SIZE)
 
     /**
@@ -114,20 +115,33 @@ class LyricsHelper @Inject constructor(
      * Lookup lyrics from remote providers
      */
     private suspend fun getRemoteLyrics(mediaMetadata: MediaMetadata): String? {
+        val artistName = mediaMetadata.artists
+            .filter { it.id != null }
+            .joinToString { it.name.removeSuffix(" - Topic") }
+            .ifEmpty { mediaMetadata.artists.joinToString { it.name } }
+        Log.d(TAG, "getLyrics start: videoId=${mediaMetadata.id} title=\"${mediaMetadata.title}\" artist=\"${artistName}\"")
         lyricsProviders.forEach { provider ->
             if (provider.isEnabled(context)) {
+                val t0 = System.currentTimeMillis()
                 provider.getLyrics(
                     mediaMetadata.id,
                     mediaMetadata.title,
-                    mediaMetadata.artists.joinToString { it.name },
+                    artistName,
                     mediaMetadata.duration
                 ).onSuccess { lyrics ->
+                    val elapsed = System.currentTimeMillis() - t0
+                    Log.d(TAG, "${provider.name} SUCCESS in ${elapsed}ms")
                     return lyrics
                 }.onFailure {
+                    val elapsed = System.currentTimeMillis() - t0
+                    Log.d(TAG, "${provider.name} FAILURE in ${elapsed}ms: ${it.message}")
                     reportException(it)
                 }
+            } else {
+                Log.d(TAG, "${provider.name} SKIPPED (disabled)")
             }
         }
+        Log.d(TAG, "getLyrics end: all providers exhausted for videoId=${mediaMetadata.id}")
         return null
     }
 
@@ -176,6 +190,7 @@ class LyricsHelper @Inject constructor(
     }
 
     companion object {
+        private const val TAG = "LyricsHelper"
         private const val MAX_CACHE_SIZE = 3
     }
 }

--- a/lrclib/src/main/java/com/dd3boh/lrclib/LrcLib.kt
+++ b/lrclib/src/main/java/com/dd3boh/lrclib/LrcLib.kt
@@ -45,7 +45,6 @@ object LrcLib {
             parameter("artist_name", artist)
             if (album != null) parameter("album_name", album)
         }.body<List<Track>>()
-        .filter { it.syncedLyrics != null }
 
     suspend fun getLyrics(
         title: String,
@@ -53,9 +52,8 @@ object LrcLib {
         duration: Int,
         album: String? = null,
     ) = runCatching {
-        val tracks = queryLyrics(artist, title, album)
-
-        val res = tracks.bestMatchingFor(duration)?.syncedLyrics?.let(LrcLib::Lyrics)
+        val syncedTracks = queryLyrics(artist, title, album).filter { it.syncedLyrics != null }
+        val res = syncedTracks.bestMatchingFor(duration)?.syncedLyrics?.let(LrcLib::Lyrics)
         if (res != null) {
             return@runCatching res.text
         } else {

--- a/lrclib/src/main/java/com/dd3boh/lrclib/models/Track.kt
+++ b/lrclib/src/main/java/com/dd3boh/lrclib/models/Track.kt
@@ -13,4 +13,6 @@ data class Track(
     val syncedLyrics: String?,
 )
 
-internal fun List<Track>.bestMatchingFor(duration: Int) = firstOrNull { abs(it.duration.toInt() - duration) <= 2 }
+internal fun List<Track>.bestMatchingFor(duration: Int) =
+    if (duration == -1) firstOrNull()
+    else firstOrNull { abs(it.duration.toInt() - duration) <= 8 }


### PR DESCRIPTION
## Summary

Fixes #16

Lyrics display could take 3–8 seconds after playback starts because providers are queried sequentially and the first two often failed before a result was found.

- **Reorder providers**: Move YouTube Subtitle to last (LrcLib → Kugou → YouTube Music → YouTube Subtitle). YouTube Subtitle fails with `No caption tracks available` for the vast majority of YouTube Music tracks, so placing it first only added ~120ms of wasted latency before every other provider.

- **Fix LrcLib duration matching**: The previous tolerance of ±2s was too tight — YouTube Music often reports a track duration that differs from LrcLib's metadata by more than 2 seconds. Widened to ±8s (matching Kugou's existing tolerance). Also handle `duration = -1` (unknown duration) by skipping the duration check entirely, consistent with how Kugou already handles it.

- **Sanitize artist name for lyrics search**: YouTube Topic channels (auto-generated by YouTube) produce artist entries such as `"Blue - Topic"` alongside non-artist runs like `"37M views"` in the same secondary-line group. The latter has no YouTube channel ID (`id == null`) and was being passed to providers as part of the artist string, causing LrcLib searches to return 0 results. Now filters to artists with a channel ID and strips the `" - Topic"` suffix before querying.

- **Add per-provider timing logs**: `LyricsHelper` now logs each provider's result and elapsed time under the `LyricsHelper` tag, making future diagnosis easier.

## Test plan

- [x] Play a song backed by a YouTube Topic channel — confirm LrcLib returns lyrics without the artist name being contaminated
- [x] Play a song whose `duration` is reported as `-1` — confirm lyrics are returned by LrcLib instead of falling through to Kugou
- [x] Confirm lyrics appear faster than before for songs where LrcLib succeeds
- [x] Confirm logcat shows `LyricsHelper` timing entries for each provider