### PR TITLE
fix(player): improve YTM thumbnail resolution

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/models/MediaMetadata.kt
+++ b/app/src/main/java/com/dd3boh/outertune/models/MediaMetadata.kt
@@ -161,7 +161,7 @@ fun SongItem.toMediaMetadata() = MediaMetadata(
         )
     },
     duration = duration ?: -1,
-    thumbnailUrl = thumbnail.resize(544, 544),
+    thumbnailUrl = thumbnail.resize(1080, 1080),
     album = album?.let {
         MediaMetadata.Album(
             id = it.id,

--- a/app/src/main/java/com/dd3boh/outertune/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/utils/YouTubeUtils.kt
@@ -5,7 +5,7 @@ fun String.resize(
     height: Int? = null,
 ): String {
     if (width == null && height == null) return this
-    "https://lh3\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex().matchEntire(this)?.groupValues?.let { group ->
+    "https://[a-z0-9]+\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex().matchEntire(this)?.groupValues?.let { group ->
         val (W, H) = group.drop(1).map { it.toInt() }
         var w = width
         var h = height
@@ -15,6 +15,18 @@ fun String.resize(
     }
     if (this matches "https://yt3\\.ggpht\\.com/.*=s(\\d+)".toRegex()) {
         return "$this-s${width ?: height}"
+    }
+    if (this.contains("i.ytimg.com")) {
+        val w = width ?: height!!
+        return if (w > 480) {
+            this.replace("hqdefault.jpg", "maxresdefault.jpg")
+                .replace("mqdefault.jpg", "maxresdefault.jpg")
+                .replace("sddefault.jpg", "maxresdefault.jpg")
+        } else if (w > 320) {
+            this.replace("mqdefault.jpg", "hqdefault.jpg")
+        } else {
+            this
+        }
     }
     return this
 }


### PR DESCRIPTION
### What is it?

- [x] Bugfix (user facing)

### Description of the changes in your PR

`resize` only matched `lh3.googleusercontent.com`, so the common
`yt3.googleusercontent.com` and `i.ytimg.com` thumbnail URLs were returned
unchanged and shown at their original low resolution (e.g. 120x120), which
looked blurry in the player.

- Match any `*.googleusercontent.com` subdomain (lh3, yt3, etc.)
- Add `i.ytimg.com` handling: upgrade hq/mq/sddefault.jpg to maxresdefault.jpg (1280x720)
- Request 1080x1080 instead of 544x544 for song thumbnails

> [!note]
> Songs already saved in the local database keep their old low-resolution URL.
> Clearing the app's storage (or otherwise re-fetching the metadata) is required
> for those to update. Newly played songs are unaffected.

### Fixes the following issue(s)

- Fixes OuterTune/OuterTune#1247

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
