### PR TITLE
feat(player): add lyrics toggle button to now-playing action buttons

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -55,9 +55,11 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Lyrics as LyricsOutlined
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
+import androidx.compose.material.icons.rounded.Lyrics as LyricsRounded
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -558,7 +560,28 @@ fun ActionButtons(
     val currentSong by playerConnection.currentSong.collectAsState(initial = null)
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
+    var showLyrics by rememberPreference(ShowLyricsKey, defaultValue = false)
+
     Spacer(modifier = Modifier.width(10.dp))
+
+    Box(
+        modifier = Modifier
+            .offset(y = 5.dp)
+            .size(36.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.primary)
+    ) {
+        ResizableIconButton(
+            icon = if (showLyrics) Icons.Rounded.LyricsRounded else Icons.Outlined.LyricsOutlined,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(24.dp),
+            onClick = { showLyrics = !showLyrics }
+        )
+    }
+
+    Spacer(modifier = Modifier.width(7.dp))
 
     Box(
         modifier = Modifier


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Adds an icon-only lyrics button to the now-playing action row, placed to the left of the favorite (heart) button.
- Tapping it toggles the existing `ShowLyricsKey` preference, so it stays in sync with the "Toggle lyrics" menu item and the thumbnail tap.
- The icon reflects the current state with the same filled/outline pattern as the favorite button: `Icons.Rounded.Lyrics` when lyrics are shown and `Icons.Outlined.Lyrics` when hidden.
- The button is added in the single `ActionButtons` composable, which is shared by the portrait and landscape layouts, so both are covered.

### Before/After Screenshots/Screen Record

- Before: The action row had only the favorite (heart) and overflow menu buttons; lyrics could only be toggled by tapping the thumbnail.
- After: A lyrics toggle button is added to the left of the heart (order: lyrics → favorite → menu). Its state is shown with an outlined icon when off and a filled icon when on.

<img width="1280" height="800" alt="Screenshot_20260615_164450" src="https://github.com/user-attachments/assets/f051b763-dc11-41b6-a2ca-b265571a474d" />
<img width="270" height="600" alt="Screenshot_20260615_164846" src="https://github.com/user-attachments/assets/e3229033-7217-4775-b993-e1378dcb4388" />


### Fixes the following issue(s)

- None

### Relies on the following changes

- None

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)
