### PR TITLE
fix(nav): navigate directly to tab root on bottom nav and nav rail tap

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -797,15 +797,21 @@ class MainActivity : ComponentActivity() {
                                                     playerBottomSheetState.collapseSoft()
                                                 }
 
-                                                if (navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true) {
-                                                    navBackStackEntry?.savedStateHandle?.set(
-                                                        "scrollToTop",
-                                                        true
-                                                    )
-                                                } else if (navigationItems.none { scr -> navBackStackEntry?.destination?.hierarchy?.any { it.route == scr.route } == true }) {
-                                                    // this eye bleach allows you to navigate back when you tap on the navbar on a non-root page
-                                                    // TODO: nav3 allows us to access back stack... maybe do indicators properly and remove this hack
-                                                    navController.navigateUp()
+                                                val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
+                                                val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
+
+                                                if (screen.route == Screens.Home.route) {
+                                                    navController.navigate(screen.route) {
+                                                        popUpTo(navController.graph.startDestinationId) {
+                                                            saveState = true
+                                                        }
+                                                        launchSingleTop = true
+                                                    }
+                                                } else if (isCurrentTab || isInCurrentTabStack) {
+                                                    navController.navigate(screen.route) {
+                                                        popUpTo(screen.route)
+                                                        launchSingleTop = true
+                                                    }
                                                 } else {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
@@ -897,17 +903,26 @@ class MainActivity : ComponentActivity() {
                                                 if (playerBottomSheetState.isExpanded) {
                                                     playerBottomSheetState.collapseSoft()
                                                 }
-                                                if (navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true) {
-                                                    navBackStackEntry?.savedStateHandle?.set(
-                                                        "scrollToTop",
-                                                        true
-                                                    )
+                                                val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
+                                                val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
+
+                                                if (screen.route == Screens.Home.route) {
+                                                    navController.navigate(screen.route) {
+                                                        popUpTo(navController.graph.startDestinationId) {
+                                                            saveState = true
+                                                        }
+                                                        launchSingleTop = true
+                                                    }
+                                                } else if (isCurrentTab || isInCurrentTabStack) {
+                                                    navController.navigate(screen.route) {
+                                                        popUpTo(screen.route)
+                                                        launchSingleTop = true
+                                                    }
                                                 } else {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
                                                             saveState = true
                                                         }
-
                                                         launchSingleTop = true
                                                         restoreState = true
                                                     }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Remove the `navigateUp()` hack in the bottom navigation bar that caused tapping a nav item from a non-root page (e.g. album, artist, search results) to go back instead of navigating to the selected tab.
- Use `currentBackStack` to detect when the current destination is nested under a tab (e.g. `folders/{path}`, library sub-screens), and pop to that tab's root when the tab is tapped.
- Give the Home tab special handling: always navigate to the Home root without restoring saved state, while preserving other tabs' state via `saveState`.
- Apply the same fix to the navigation rail.

### Before/After Screenshots/Screen Record

| Scenario | Before | After |
|---|---|---|
| Tap any tab from a non-root screen (e.g. album detail, artist detail) | Navigates **back** to the previous screen instead of going to the selected tab | Navigates **directly** to the selected tab's root |
| Tap Home from any screen | May restore a previously visited screen (e.g. artist detail) instead of showing the Home root | Always shows the **Home root** |
| Re-tap Folders while inside a sub-folder | Stays on the sub-folder screen | **Pops back** to the Folders root |
| Re-tap Library while in a sub-screen | Stays on the sub-screen | **Pops back** to the Library root |
| Switch to another tab and return (e.g. Library → Home → Library) | Returns to the **Library root**, losing the previous position | **Restores** the previous position in Library |

### Due diligence

- [ ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way that adheres to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)