### PR TITLE
refactor(innertube): remove redundant safe calls in YouTube.kt

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -246,8 +246,8 @@ object YouTube {
                 AlbumPage.getSong(it)
             }!!
             .toMutableList()
-        var continuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
-            ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation()
+        var continuation = response.contents.twoColumnBrowseResultsRenderer.secondaryContents.sectionListRenderer
+            .contents.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation()
         while (continuation != null) {
             response = innerTube.browse(
                 client = WEB_REMIX,
@@ -447,7 +447,7 @@ object YouTube {
             .mapNotNull {
                 HomePage.Section.fromMusicCarouselShelfRenderer(it)
             }.toMutableList()
-        val chips = sectionListRender?.header?.chipCloudRenderer?.chips?.mapNotNull { HomePage.Chip.fromChipCloudChipRenderer(it) }
+        val chips = sectionListRender.header?.chipCloudRenderer?.chips?.mapNotNull { HomePage.Chip.fromChipCloudChipRenderer(it) }
         HomePage(chips, sections, continuation)
     }
 


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Remove unnecessary `?.` safe calls in `YouTube.kt` that the Kotlin compiler flagged as redundant.

- `albumSongs()`: the `!!` assertion a few lines above smart-casts the `response.contents` chain to non-null, so the safe calls up to `firstOrNull()` were redundant.
- `home()`: `sectionListRender` is already non-null from the `!!` on its assignment, so the safe call on `.header` was redundant.

These paths are only reached after the preceding non-null assertions hold, so there is no behavioral change. This clears the two "Unnecessary safe call" warnings emitted during `:innertube:compileKotlin`. Verified with a full `installFullDebug` build (BUILD SUCCESSFUL).

### Before/After Screenshots/Screen Record

N/A (no UI changes)

### Fixes the following issue(s)

N/A 

### Relies on the following changes

N/A 

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the merger to modify my code to solve merge conflicts.
