### PR TITLE
fix(ui): fix search bar visibility and list position on navigation

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -800,6 +800,12 @@ class MainActivity : ComponentActivity() {
                                                 val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
                                                 val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
 
+                                                if (isCurrentTab) {
+                                                    navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
+                                                    scrollBehavior.state.heightOffset = 0f
+                                                    scrollBehavior.state.contentOffset = 0f
+                                                }
+
                                                 if (screen.route == Screens.Home.route) {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
@@ -905,6 +911,12 @@ class MainActivity : ComponentActivity() {
                                                 }
                                                 val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
                                                 val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
+
+                                                if (isCurrentTab) {
+                                                    navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
+                                                    scrollBehavior.state.heightOffset = 0f
+                                                    scrollBehavior.state.contentOffset = 0f
+                                                }
 
                                                 if (screen.route == Screens.Home.route) {
                                                     navController.navigate(screen.route) {

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -145,10 +145,18 @@ fun SearchBarContainer(
                 navBackStackEntry?.destination?.route?.startsWith("search/") == true)
     }
 
+    val savedHeightOffsets = remember { mutableMapOf<String, Float>() }
+    var previousRoute by remember { mutableStateOf<String?>(null) }
+
     LaunchedEffect(navBackStackEntry) {
         if (searchActive) {
             onSearchActiveChange(false)
         }
+        val currentRoute = navBackStackEntry?.destination?.route
+        previousRoute?.let { savedHeightOffsets[it] = scrollBehavior.state.heightOffset }
+        scrollBehavior.state.heightOffset = savedHeightOffsets[currentRoute] ?: 0f
+        scrollBehavior.state.contentOffset = 0f
+        previousRoute = currentRoute
     }
 
     AnimatedVisibility(


### PR DESCRIPTION
### What is it?

- [x] Bugfix (user facing)

### Description of the changes in your PR

- Save and restore the search bar height offset per destination route on navigation. Screens visited for the first time always show the search bar; returning to a
previously scrolled screen restores the bar to its prior position.
- Reset the search bar and scroll the list to the top when the user taps the currently active bottom navigation item. Applies to both NavigationBar and NavigationRail.

### Before/After Screenshots/Screen Record

- N/A

### Fixes the following issue(s)

- N/A

## Due diligence

- [ ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
or squash my code, or apply merge conflict amendments as needed