### PR TITLE
Resolve Android Studio Inspect Code findings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -798,7 +798,7 @@ class MainActivity : ComponentActivity() {
                                                 }
 
                                                 val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
-                                                val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
+                                                val isInCurrentTabStack = !isCurrentTab && runCatching { navController.getBackStackEntry(screen.route) }.isSuccess
 
                                                 if (isCurrentTab) {
                                                     navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
@@ -910,7 +910,7 @@ class MainActivity : ComponentActivity() {
                                                     playerBottomSheetState.collapseSoft()
                                                 }
                                                 val isCurrentTab = navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } == true
-                                                val isInCurrentTabStack = !isCurrentTab && navController.currentBackStack.value.any { it.destination.route == screen.route }
+                                                val isInCurrentTabStack = !isCurrentTab && runCatching { navController.getBackStackEntry(screen.route) }.isSuccess
 
                                                 if (isCurrentTab) {
                                                     navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)

--- a/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
@@ -216,7 +216,7 @@ class DownloadUtil @Inject constructor(
         }
 
         runBlocking {
-            database.song(id).first()?.song?.copy(localPath = null)
+            database.song(id).first()?.song?.copy(localPath = null)?.let { database.update(it) }
             database.updateDownloadStatus(id, null)
         }
         return true

--- a/app/src/main/java/com/dd3boh/outertune/ui/dialog/ImportM3uDialog.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/dialog/ImportM3uDialog.kt
@@ -380,7 +380,7 @@ suspend fun loadM3u(
                             }
                         }
                         val oldSize = songs.size
-                        var foundOne = false // TODO: Eventually the user can pick from matches... eventually...
+                        // TODO: Eventually the user can pick from matches... eventually...
 
                         // take first song when searching on YTM
                         if (matchStrength == ScannerM3uMatchCriteria.LEVEL_0 && searchOnline && matches.isNotEmpty()) {
@@ -389,7 +389,6 @@ suspend fun loadM3u(
                             for (s in matches) {
                                 if (compareM3uSong(mockSong, s, matchStrength = matchStrength)) {
                                     songs.add(s)
-                                    foundOne = true
                                     break
                                 }
                             }

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
@@ -294,7 +294,7 @@ fun PlayerMenu(
                         TextField(
                             value = textFieldValue,
                             onValueChange = onTextFieldValueChange,
-                            placeholder = { pluralString },
+                            placeholder = { Text(pluralString) },
                             singleLine = true,
                             leadingIcon = { Icon(Icons.Rounded.MoreTime, null) },
                             colors = OutlinedTextFieldDefaults.colors(),

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -496,7 +496,7 @@ fun LandscapePlayer(
                     rows = GridCells.Fixed(1),
                     contentPadding = PaddingValues(vertical = 16.dp),
                     flingBehavior = rememberSnapFlingBehavior(thumbnailSnapLayoutInfoProvider),
-                    userScrollEnabled = playerSheetState.isExpanded && swipeToSkip
+                    userScrollEnabled = playerSheetState.isExpanded
                 ) {
                     items(
                         items = mediaItems,

--- a/app/src/main/java/com/dd3boh/outertune/utils/scanners/LocalMediaScanner.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/scanners/LocalMediaScanner.kt
@@ -71,7 +71,9 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
-class LocalMediaScanner(val context: Context, scannerImpl: ScannerImpl) {
+class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
+    // Hold the application context to avoid leaking an Activity/Service through the static scanner instance
+    val context: Context = context.applicationContext
     private val TAG = LocalMediaScanner::class.simpleName.toString()
     private var advancedScannerImpl: MetadataScanner = when (scannerImpl) {
         ScannerImpl.FFMPEG_EXT -> if (ENABLE_FFMETADATAEX) FFmpegScanner() else MediaStoreExtractor()


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

These changes address correctness and code-quality findings surfaced by Android Studio's Inspect Code.

Bug fixes (user facing):
- `DownloadUtil.deleteSong`: persist the cleared `localPath`. The result of `copy(localPath = null)` was discarded, so the database kept a `localPath` pointing to an already deleted file. It is now saved through the existing `SongsDao.update`.
- `PlayerMenu` sleep timer: the manual-input field placeholder referenced the plural string without rendering it. It is now wrapped in `Text()` so the placeholder is shown.

Code-quality cleanups (dev facing):
- `ImportM3uDialog`: removed the write-only `foundOne` variable; the accept/reject decision already relies on the song-count comparison.
- `Player` (landscape): removed the redundant `&& swipeToSkip`, which is always true inside that `else` branch.
- `MainActivity`: replaced the restricted `NavController.currentBackStack` access with the public `getBackStackEntry` check in the two tab-reselect handlers.
- `LocalMediaScanner`: hold the application context instead of the passed-in context, so the static scanner instance no longer leaks an Activity or Service.
- `AndroidManifest`: dropped the unused `FOREGROUND_SERVICE_SPECIAL_USE` permission; no service declares the `specialUse` type.

Findings that were intentionally left unchanged are out of scope for this PR: a false-positive constant-condition on a StateFlow value, the Catalan plural (`many`) completeness in a community-translation file, and the existing `runBlocking` usages.

### Before/After Screenshots/Screen Record

The only user-visible change is the sleep timer manual-input placeholder, which now renders its text. No screenshots attached.

### Fixes the following issue(s)

- N/A (the findings come from Android Studio Inspect Code, not a tracked issue)

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the merger to modify my code to solve merge conflicts.
