### PR TITLE
refactor: gate verbose logs behind per-area debug flags

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -16,6 +16,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -221,7 +222,7 @@ class MainActivity : ComponentActivity() {
         }
 
     override fun onDestroy() {
-        Log.i(MAIN_TAG, "onDestroy() called. isFinishing = $isFinishing")
+        if (UI_DEBUG) Log.i(MAIN_TAG, "onDestroy() called. isFinishing = $isFinishing")
         try {
             connectivityObserver.unregister()
         } catch (e: UninitializedPropertyAccessException) {
@@ -251,7 +252,7 @@ class MainActivity : ComponentActivity() {
         activityLauncher = ActivityLauncherHelper(this)
 
         setContent {
-            Log.v(MAIN_TAG, "RC-1")
+            if (UI_DEBUG) Log.v(MAIN_TAG, "RC-1")
             val coroutineScope = rememberCoroutineScope()
             val haptic = LocalHapticFeedback.current
             val snackbarHostState = remember { SnackbarHostState() }
@@ -322,7 +323,7 @@ class MainActivity : ComponentActivity() {
                 pureBlack = pureBlack,
                 highContrastCompat = highContrastCompat,
             ) {
-                Log.v(MAIN_TAG, "RC-2.1")
+                if (UI_DEBUG) Log.v(MAIN_TAG, "RC-2.1")
                 val density = LocalDensity.current
                 val windowsInsets = WindowInsets.systemBars
                 val bottomInset = with(density) { windowsInsets.getBottom(density).toDp() }
@@ -360,7 +361,7 @@ class MainActivity : ComponentActivity() {
                         .background(MaterialTheme.colorScheme.surface)
                 ) {
                     val maxW = maxWidth
-                    Log.v(MAIN_TAG, "RC-2.2")
+                    if (UI_DEBUG) Log.v(MAIN_TAG, "RC-2.2")
 
                     fun getNavPadding(): Dp {
                         return if (!useNavRail) (if (slimNav) 52.dp else 68.dp) else MinMiniPlayerHeight
@@ -442,7 +443,7 @@ class MainActivity : ComponentActivity() {
                             modifier = Modifier
                                 .fillMaxSize()
                         ) {
-                            Log.v(MAIN_TAG, "RC-3")
+                            if (UI_DEBUG) Log.v(MAIN_TAG, "RC-3")
 
 
                             val navHost: @Composable() (() -> Unit) = @Composable {

--- a/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
@@ -94,3 +94,6 @@ const val EXTRACTOR_DEBUG = false
 const val DEBUG_SAVE_OUTPUT = false // ignored (will be false) when EXTRACTOR_DEBUG IS false
 
 const val QUEUE_DEBUG = false
+
+// enable verbose debugging details for the player and queue UI
+const val PLAYER_DEBUG = false

--- a/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
@@ -97,3 +97,18 @@ const val QUEUE_DEBUG = false
 
 // enable verbose debugging details for the player and queue UI
 const val PLAYER_DEBUG = false
+
+// enable verbose debugging details for library/account sync
+const val SYNC_DEBUG = false
+
+// enable verbose debugging details for the download manager
+const val DOWNLOAD_DEBUG = false
+
+// enable verbose debugging details for the playback service
+const val SERVICE_DEBUG = false
+
+// enable verbose debugging details for PoToken generation
+const val POTOKEN_DEBUG = false
+
+// enable verbose debugging details for miscellaneous UI screens
+const val UI_DEBUG = false

--- a/app/src/main/java/com/dd3boh/outertune/models/DirectoryTree.kt
+++ b/app/src/main/java/com/dd3boh/outertune/models/DirectoryTree.kt
@@ -9,6 +9,7 @@
 package com.dd3boh.outertune.models
 
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastSumBy
 import com.dd3boh.outertune.constants.FolderSongSortType
@@ -81,7 +82,7 @@ class DirectoryTree(path: String, var culmSongs: CulmSongs) {
             files.add(song)
             culmSongs.value++
             if (SCANNER_DEBUG)
-                Log.v(TAG, "Adding song with path: $path")
+                if (UI_DEBUG) Log.v(TAG, "Adding song with path: $path")
             return
         }
 
@@ -125,12 +126,12 @@ class DirectoryTree(path: String, var culmSongs: CulmSongs) {
      * @return song at path, or null if it does not exist
      */
     fun getSong(path: String): Song? {
-        Log.v(TAG, "Searching for song, at path: $path")
+        if (UI_DEBUG) Log.v(TAG, "Searching for song, at path: $path")
 
         // search for song in current dir
         if (path.indexOf('/') == -1) {
             val foundSong: Song = files.first { getFileName(it.song.localPath) == getFileName(path) }
-            Log.v(TAG, "Searching for song, found?: ${foundSong.id} Name: ${foundSong.song.title}")
+            if (UI_DEBUG) Log.v(TAG, "Searching for song, found?: ${foundSong.id} Name: ${foundSong.song.title}")
             return foundSong
         }
 

--- a/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
@@ -20,6 +20,7 @@ import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.dd3boh.outertune.constants.AudioQuality
 import com.dd3boh.outertune.constants.AudioQualityKey
+import com.dd3boh.outertune.constants.DOWNLOAD_DEBUG
 import com.dd3boh.outertune.constants.DownloadExtraPathKey
 import com.dd3boh.outertune.constants.DownloadPathKey
 import com.dd3boh.outertune.db.MusicDatabase
@@ -291,7 +292,7 @@ class DownloadUtil @Inject constructor(
             val toMigrate = downloadedSongs.filter { it.value.state == Download.STATE_COMPLETED }
             toMigrate.forEach { s ->
                 if (runs++ % 10 == 0) {
-                    Log.d(TAG, "Migrating download: $runs/${toMigrate.size}")
+                    if (DOWNLOAD_DEBUG) Log.d(TAG, "Migrating download: $runs/${toMigrate.size}")
                     if (runs % 20 == 0) {
                         withContext(Dispatchers.Main) {
                             Toast.makeText(context, "$runs/${toMigrate.size}", LENGTH_SHORT).show()
@@ -328,7 +329,7 @@ class DownloadUtil @Inject constructor(
      * Rescan download directory and updates songs
      */
     suspend fun rescanDownloads() {
-        Log.i(TAG, "+rescanDownloads()")
+        if (DOWNLOAD_DEBUG) Log.i(TAG, "+rescanDownloads()")
         isProcessingDownloads.value = true
         val dbDownloads = database.downloadedOrQueuedSongs().first()
         val result = mutableMapOf<String, LocalDateTime>()
@@ -336,19 +337,19 @@ class DownloadUtil @Inject constructor(
         // get missing files not in custom downloads or in internal downloads, remove them
         val missingFiles =
             localMgr.getMissingFiles(dbDownloads.filterNot { it.song.dateDownload == null }).toMutableList()
-        Log.d(TAG, "Found ${missingFiles.size}/${dbDownloads.size} songs not in custom download directories")
+        if (DOWNLOAD_DEBUG) Log.d(TAG, "Found ${missingFiles.size}/${dbDownloads.size} songs not in custom download directories")
         val cursor = downloadManager.downloadIndex.getDownloads()
         while (cursor.moveToNext()) {
             missingFiles.removeIf { it.id == cursor.download.request.id }
         }
-        Log.d(
+        if (DOWNLOAD_DEBUG) Log.d(
             TAG,
             "Found ${missingFiles.size}/${dbDownloads.size} song not in custom download directories + internal cache. Removing these files now"
         )
 
         database.transaction {
             missingFiles.forEach {
-                Log.v(TAG, "Shedding: [${it.id}] ${it.song.title}")
+                if (DOWNLOAD_DEBUG) Log.v(TAG, "Shedding: [${it.id}] ${it.song.title}")
                 removeDownloadSong(it.song.id)
             }
         }
@@ -361,7 +362,7 @@ class DownloadUtil @Inject constructor(
 
         downloads.value = result
         isProcessingDownloads.value = false
-        Log.i(TAG, "-rescanDownloads()")
+        if (DOWNLOAD_DEBUG) Log.i(TAG, "-rescanDownloads()")
     }
 
 
@@ -372,9 +373,9 @@ class DownloadUtil @Inject constructor(
      * songs will already need to exist in the database.
      */
     suspend fun scanDownloads() {
-        Log.i(TAG, "+scanDownloads()")
+        if (DOWNLOAD_DEBUG) Log.i(TAG, "+scanDownloads()")
         if (isProcessingDownloads.value) {
-            Log.i(TAG, "-scanDownloads()")
+            if (DOWNLOAD_DEBUG) Log.i(TAG, "-scanDownloads()")
             return
         }
         isProcessingDownloads.value = true
@@ -403,7 +404,7 @@ class DownloadUtil @Inject constructor(
             }
         }
 //            LocalMediaScanner.destroyScanner(SCANNER_OWNER_DL)
-        Log.d(TAG, "Registered ${availableFiles.size} files from custom downloads")
+        if (DOWNLOAD_DEBUG) Log.d(TAG, "Registered ${availableFiles.size} files from custom downloads")
 
         // add internal downloads
         val cursor = downloadManager.downloadIndex.getDownloads()
@@ -414,11 +415,11 @@ class DownloadUtil @Inject constructor(
                 count ++
             }
         }
-        Log.d(TAG, "Registered $count files from internal downloads")
+        if (DOWNLOAD_DEBUG) Log.d(TAG, "Registered $count files from internal downloads")
         isProcessingDownloads.value = false
-        Log.d(TAG, "Database registration complete, triggering map registry rebuild")
+        if (DOWNLOAD_DEBUG) Log.d(TAG, "Database registration complete, triggering map registry rebuild")
         rescanDownloads()
-        Log.i(TAG, "-scanDownloads()")
+        if (DOWNLOAD_DEBUG) Log.i(TAG, "-scanDownloads()")
     }
 
     companion object {
@@ -428,7 +429,7 @@ class DownloadUtil @Inject constructor(
 
 
     init {
-        Log.i(TAG, "DownloadUtil init")
+        if (DOWNLOAD_DEBUG) Log.i(TAG, "DownloadUtil init")
         // TODO: make sure db is update when download is queued
         CoroutineScope(dlCoroutine).launch {
             rescanDownloads()

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -66,6 +66,7 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionToken
 import com.dd3boh.outertune.MainActivity
 import com.dd3boh.outertune.R
+import com.dd3boh.outertune.constants.SERVICE_DEBUG
 import com.dd3boh.outertune.constants.AudioDecoderKey
 import com.dd3boh.outertune.constants.AudioGaplessOffloadKey
 import com.dd3boh.outertune.constants.AudioNormalizationKey
@@ -226,7 +227,7 @@ class MusicService : MediaLibraryService(),
     var consecutivePlaybackErr = 0
 
     override fun onCreate() {
-        Log.i(TAG, "Starting MusicService")
+        if (SERVICE_DEBUG) Log.i(TAG, "Starting MusicService")
         super.onCreate()
 
         player = ExoPlayer.Builder(this)
@@ -301,7 +302,7 @@ class MusicService : MediaLibraryService(),
 
         // lateinit tasks
         offloadScope.launch {
-            Log.i(TAG, "Launching MusicService offloadScope tasks")
+            if (SERVICE_DEBUG) Log.i(TAG, "Launching MusicService offloadScope tasks")
             if (!qbInit.value) {
                 initQueue()
             }
@@ -473,7 +474,7 @@ class MusicService : MediaLibraryService(),
         val preloadItem = queue.preloadItem
         // do not use scope.launch ... it breaks randomly... why is this bug back???
         CoroutineScope(Dispatchers.Main).launch {
-            Log.d(TAG, "playQueue: Resolving additional queue data...")
+            if (SERVICE_DEBUG) Log.d(TAG, "playQueue: Resolving additional queue data...")
             try {
                 if (preloadItem != null) {
                     q = queueBoard.value.addQueue(
@@ -497,7 +498,7 @@ class MusicService : MediaLibraryService(),
                 }
 
                 val items = ArrayList<MediaMetadata>()
-                Log.d(TAG, "playQueue: Queue initial status item count: ${initialStatus.items.size}")
+                if (SERVICE_DEBUG) Log.d(TAG, "playQueue: Queue initial status item count: ${initialStatus.items.size}")
                 if (!initialStatus.items.isEmpty()) {
                     if (preloadItem != null) {
                         items.add(preloadItem)
@@ -524,7 +525,7 @@ class MusicService : MediaLibraryService(),
                     .show()
             }
 
-            Log.d(TAG, "playQueue: Queue additional data resolution complete")
+            if (SERVICE_DEBUG) Log.d(TAG, "playQueue: Queue additional data resolution complete")
         }
     }
 
@@ -577,7 +578,7 @@ class MusicService : MediaLibraryService(),
     }
 
     suspend fun initQueue() {
-        Log.i(TAG, "+initQueue()")
+        if (SERVICE_DEBUG) Log.i(TAG, "+initQueue()")
         val persistQueue = dataStore.get(PersistentQueueKey, true)
         val maxQueues = dataStore.get(MaxQueuesKey, 19)
         if (persistQueue) {
@@ -585,13 +586,13 @@ class MusicService : MediaLibraryService(),
         } else {
             queueBoard.value = QueueBoard(this, queueBoard.value.masterQueues, maxQueues = maxQueues)
         }
-        Log.d(TAG, "Queue with $maxQueues queue limit. Persist queue = $persistQueue. Queues loaded = ${queueBoard.value.masterQueues.size}")
+        if (SERVICE_DEBUG) Log.d(TAG, "Queue with $maxQueues queue limit. Persist queue = $persistQueue. Queues loaded = ${queueBoard.value.masterQueues.size}")
         qbInit.value = true
-        Log.i(TAG, "-initQueue()")
+        if (SERVICE_DEBUG) Log.i(TAG, "-initQueue()")
     }
 
     fun deInitQueue() {
-        Log.i(TAG, "+deInitQueue()")
+        if (SERVICE_DEBUG) Log.i(TAG, "+deInitQueue()")
         val pos = player.currentPosition
         queueBoard.value.shutdown()
         if (dataStore.get(PersistentQueueKey, true)) {
@@ -601,7 +602,7 @@ class MusicService : MediaLibraryService(),
         }
         // do not replace the object. Can lead to entire queue being deleted even though it is supposed to be saved already
         qbInit.value = false
-        Log.i(TAG, "-deInitQueue()")
+        if (SERVICE_DEBUG) Log.i(TAG, "-deInitQueue()")
     }
 
     suspend fun saveQueueToDisk(currentPosition: Long) {
@@ -655,7 +656,7 @@ class MusicService : MediaLibraryService(),
                     .setCacheWriteDataSinkFactory(
                         HybridCacheDataSinkFactory(playerCache) { dataSpec ->
                             val isLocal = queueBoard.value.getCurrentQueue()?.findSong(dataSpec.key ?: "")?.isLocal == true
-                            Log.d(TAG, "SONG CACHE: ${!isLocal}")
+                            if (SERVICE_DEBUG) Log.d(TAG, "SONG CACHE: ${!isLocal}")
                             !isLocal
                         }
                     )
@@ -669,7 +670,7 @@ class MusicService : MediaLibraryService(),
         val songUrlCache = HashMap<String, Pair<String, Long>>()
         return ResolvingDataSource.Factory(createCacheDataSource()) { dataSpec ->
             val mediaId = dataSpec.key ?: error("No media id")
-            Log.d(TAG, "PLAYING: song id = $mediaId")
+            if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: song id = $mediaId")
 
             var song = queueBoard.value.getCurrentQueue()?.findSong(dataSpec.key ?: "")
             if (song == null) { // in the case of resumption, queueBoard may not be ready yet
@@ -678,7 +679,7 @@ class MusicService : MediaLibraryService(),
             // local song
             if (song?.localPath != null) {
                 if (song.isLocal) {
-                    Log.d(TAG, "PLAYING: local song")
+                    if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: local song")
                     val file = File(song.localPath)
                     if (!file.exists()) {
                         throw PlaybackException(
@@ -692,7 +693,7 @@ class MusicService : MediaLibraryService(),
                 } else {
                     val isDownloadNew = downloadUtil.localMgr.getFilePathIfExists(mediaId)
                     isDownloadNew?.let {
-                        Log.d(TAG, "PLAYING: Custom downloaded song")
+                        if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: Custom downloaded song")
                         return@Factory dataSpec.withUri(it)
                     }
                 }
@@ -702,18 +703,18 @@ class MusicService : MediaLibraryService(),
                 downloadCache.isCached(mediaId, dataSpec.position, if (dataSpec.length >= 0) dataSpec.length else 1)
             val isCache = playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)
             if (isDownload || isCache) {
-                Log.d(TAG, "PLAYING: remote song (cache = ${isCache}, download = ${isDownload})")
+                if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: remote song (cache = ${isCache}, download = ${isDownload})")
                 offloadScope.launch { recoverSong(mediaId) }
                 return@Factory dataSpec
             }
 
             songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {
-                Log.d(TAG, "PLAYING: remote song (temp cache)")
+                if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: remote song (temp cache)")
                 offloadScope.launch { recoverSong(mediaId) }
                 return@Factory dataSpec.withUri(it.first.toUri())
             }
 
-            Log.d(TAG, "PLAYING: remote song (online fetch)")
+            if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: remote song (online fetch)")
 
             val playbackData = runBlocking(Dispatchers.IO) {
                 val audioQuality by enumPreference(this@MusicService, AudioQualityKey, AudioQuality.AUTO)
@@ -973,14 +974,14 @@ class MusicService : MediaLibraryService(),
             player.mediaItemCount - player.currentMediaItemIndex <= 5 &&
             playlistId != null // aka "hasNext"
         ) {
-            Log.d(TAG, "onMediaItemTransition: Triggering queue auto load more")
+            if (SERVICE_DEBUG) Log.d(TAG, "onMediaItemTransition: Triggering queue auto load more")
             scope.launch(SilentHandler) {
                 val endpoint = playlistId // playlistId.substringBefore("\n")
                 val continuation = null // playlistId.substringAfter("\n")
                 val yq = YouTubeQueue(WatchEndpoint(endpoint, continuation))
                 val mediaItems = yq.nextPage()
                 q.playlistId = mediaItems.takeLast(4).shuffled().first().id // yq.getContinuationEndpoint()
-                Log.d(TAG, "onMediaItemTransition: Got ${mediaItems.size} songs from radio")
+                if (SERVICE_DEBUG) Log.d(TAG, "onMediaItemTransition: Got ${mediaItems.size} songs from radio")
                 if (player.playbackState != STATE_IDLE && songCount > 1) { // initial radio loading is handled by playQueue()
                     queueBoard.value.enqueueEnd(mediaItems.drop(1))
                 }
@@ -1043,7 +1044,7 @@ class MusicService : MediaLibraryService(),
 
             val playRatio =
                 playbackStats.totalPlayTimeMs.toFloat() / ((mediaItem.metadata?.duration?.times(1000)) ?: -1)
-            Log.d(TAG, "Playback ratio: $playRatio Min threshold: $minPlaybackDur")
+            if (SERVICE_DEBUG) Log.d(TAG, "Playback ratio: $playRatio Min threshold: $minPlaybackDur")
             if (playRatio >= minPlaybackDur && !dataStore.get(PauseListenHistoryKey, false)) {
                 database.query {
                     incrementPlayCount(mediaItem.mediaId)
@@ -1061,11 +1062,11 @@ class MusicService : MediaLibraryService(),
 
                 // TODO: support playlist id
                 val ytHist = mediaItem.metadata?.isLocal != true && !dataStore.get(PauseRemoteListenHistoryKey, false)
-                Log.d(TAG, "Trying to register remote history: $ytHist")
+                if (SERVICE_DEBUG) Log.d(TAG, "Trying to register remote history: $ytHist")
                 if (ytHist) {
                     val playbackUrl = YTPlayerUtils.playerResponseForMetadata(mediaItem.mediaId, null)
                         .getOrNull()?.playbackTracking?.videostatsPlaybackUrl?.baseUrl
-                    Log.d(TAG, "Got playback url: $playbackUrl")
+                    if (SERVICE_DEBUG) Log.d(TAG, "Got playback url: $playbackUrl")
                     playbackUrl?.let {
                         YouTube.registerPlayback(null, playbackUrl)
                             .onFailure {
@@ -1105,25 +1106,25 @@ class MusicService : MediaLibraryService(),
     }
 
     override fun onDestroy() {
-        Log.i(TAG, "Terminating MusicService.")
+        if (SERVICE_DEBUG) Log.i(TAG, "Terminating MusicService.")
         deInitQueue()
 
         mediaSession.player.stop()
         mediaSession.release()
         mediaSession.player.release()
         super.onDestroy()
-        Log.i(TAG, "Terminated MusicService.")
+        if (SERVICE_DEBUG) Log.i(TAG, "Terminated MusicService.")
     }
 
     override fun onBind(intent: Intent?) = super.onBind(intent) ?: binder
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        Log.i(TAG, "onTaskRemoved called")
+        if (SERVICE_DEBUG) Log.i(TAG, "onTaskRemoved called")
         if (dataStore.get(StopMusicOnTaskClearKey, true) && !dataStore.get(KeepAliveKey, false)) {
-            Log.i(TAG, "onTaskRemoved kill")
+            if (SERVICE_DEBUG) Log.i(TAG, "onTaskRemoved kill")
             pauseAllPlayersAndStopSelf()
         } else {
-            Log.i(TAG, "onTaskRemoved def")
+            if (SERVICE_DEBUG) Log.i(TAG, "onTaskRemoved def")
             super.onTaskRemoved(rootIntent)
         }
     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -123,6 +123,7 @@ import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
 import com.dd3boh.outertune.constants.PlayerBackgroundStyle
 import com.dd3boh.outertune.constants.PlayerBackgroundStyleKey
+import com.dd3boh.outertune.constants.PLAYER_DEBUG
 import com.dd3boh.outertune.constants.PlayerHorizontalPadding
 import com.dd3boh.outertune.constants.QueuePeekHeight
 import com.dd3boh.outertune.constants.SeekIncrement
@@ -166,7 +167,7 @@ fun BottomSheetPlayer(
     modifier: Modifier = Modifier,
 ) {
     val TAG = "BottomSheetPlayer"
-    Log.v(TAG, "PLR-1")
+    if (PLAYER_DEBUG) Log.v(TAG, "PLR-1")
 
     val context = LocalContext.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -188,9 +189,9 @@ fun BottomSheetPlayer(
     val qbInit by playerConnection.service.qbInit.collectAsState()
 
     LaunchedEffect(qbInit, queueBoard.masterQueues.toList()) {
-        Log.d(TAG, "Queues changed. qbInit = $qbInit")
+        if (PLAYER_DEBUG) Log.d(TAG, "Queues changed. qbInit = $qbInit")
         if (qbInit && !queueBoard.masterQueues.isEmpty() && state.isDismissed) {
-            Log.d(TAG, "Triggering sheet collapseSoft")
+            if (PLAYER_DEBUG) Log.d(TAG, "Triggering sheet collapseSoft")
             state.collapseSoft()
         }
     }
@@ -215,7 +216,7 @@ fun BottomSheetPlayer(
             MiniPlayer()
         }
     ) {
-        Log.v(TAG, "PLR-3.0")
+        if (PLAYER_DEBUG) Log.v(TAG, "PLR-3.0")
 
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE && !context.tabMode() && context.supportsWideScreen()) {
             LandscapePlayer(state, navController, queueBoard)
@@ -234,7 +235,7 @@ fun PortraitPlayer(
     enableQueueSheet: Boolean = true,
 ) {
     val TAG = "BottomSheetPlayer"
-    Log.v(TAG, "PLR-3.1b")
+    if (PLAYER_DEBUG) Log.v(TAG, "PLR-3.1b")
 
     val playerConnection = LocalPlayerConnection.current ?: return
 
@@ -259,7 +260,7 @@ fun PortraitPlayer(
                 .weight(1f)
                 .nestedScroll(playerSheetState.preUpPostDownNestedScrollConnection)
         ) {
-            Log.v(TAG, "PLR-3.2b")
+            if (PLAYER_DEBUG) Log.v(TAG, "PLR-3.2b")
             val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
 
@@ -444,7 +445,7 @@ fun LandscapePlayer(
                 .weight(1f)
                 .nestedScroll(playerSheetState.preUpPostDownNestedScrollConnection)
         ) {
-            Log.v(TAG, "PLR-3.1a")
+            if (PLAYER_DEBUG) Log.v(TAG, "PLR-3.1a")
             if (!swipeToSkip) {
                 Thumbnail(
                     sliderPositionProvider = { sliderPosition },
@@ -551,7 +552,7 @@ fun ActionButtons(
     navController: NavController,
 ) {
     val TAG = "ActionButtons()"
-    Log.v(TAG, "PLR-AB-1")
+    if (PLAYER_DEBUG) Log.v(TAG, "PLR-AB-1")
 
     val playerConnection = LocalPlayerConnection.current ?: return
     val menuState = LocalMenuState.current
@@ -640,7 +641,7 @@ fun ControlsContent(
     showQueueHint: Boolean = false,
 ) {
     val TAG = "ControlsContent()"
-    Log.v(TAG, "PLR-CC-1")
+    if (PLAYER_DEBUG) Log.v(TAG, "PLR-CC-1")
 
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -1041,7 +1042,7 @@ fun PlayerBackground(
     useDarkTheme: Boolean,
 ) {
     val TAG = "PlayerBackground"
-    Log.v(TAG, "PLR_BG-1")
+    if (PLAYER_DEBUG) Log.v(TAG, "PLR_BG-1")
 
     val context = LocalContext.current
 
@@ -1084,7 +1085,7 @@ fun PlayerBackground(
             }
         ) { metadata ->
             if (playerBackground == PlayerBackgroundStyle.BLUR) {
-                Log.v(TAG, "PLR-2.2a")
+                if (PLAYER_DEBUG) Log.v(TAG, "PLR-2.2a")
                 AsyncImage(
                     model = metadata?.getThumbnailModel(100, 100),
                     contentDescription = null,
@@ -1104,7 +1105,7 @@ fun PlayerBackground(
             }
         ) { colors ->
             if (playerBackground == PlayerBackgroundStyle.GRADIENT && colors.size >= 2) {
-                Log.v(TAG, "PLR-2.2b")
+                if (PLAYER_DEBUG) Log.v(TAG, "PLR-2.2b")
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -1114,7 +1115,7 @@ fun PlayerBackground(
         }
 
         if (playerBackground != PlayerBackgroundStyle.FOLLOW_THEME && showLyrics) {
-            Log.v(TAG, "PLR-2.2c")
+            if (PLAYER_DEBUG) Log.v(TAG, "PLR-2.2c")
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Queue.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Queue.kt
@@ -125,6 +125,7 @@ import com.dd3boh.outertune.constants.ListItemHeight
 import com.dd3boh.outertune.constants.ListThumbnailSize
 import com.dd3boh.outertune.constants.LockQueueKey
 import com.dd3boh.outertune.constants.MiniPlayerHeight
+import com.dd3boh.outertune.constants.PLAYER_DEBUG
 import com.dd3boh.outertune.constants.PlayerHorizontalPadding
 import com.dd3boh.outertune.constants.SeekIncrement
 import com.dd3boh.outertune.constants.SeekIncrementKey
@@ -167,7 +168,7 @@ fun QueueSheet(
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
-    Log.v("QueueSheet", "Q-1")
+    if (PLAYER_DEBUG) Log.v("QueueSheet", "Q-1")
     val haptic = LocalHapticFeedback.current
     BottomSheet(
         state = state,
@@ -180,7 +181,7 @@ fun QueueSheet(
         },
         modifier = modifier,
         collapsedContent = {
-            Log.v("QueueSheet", "Q-2")
+            if (PLAYER_DEBUG) Log.v("QueueSheet", "Q-2")
             Row(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.Top,
@@ -244,7 +245,7 @@ fun BoxScope.QueueContent(
     onTerminate: () -> Unit,
     navController: NavController,
 ) {
-    Log.v("QueueContent", "QC-1")
+    if (PLAYER_DEBUG) Log.v("QueueContent", "QC-1")
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current
@@ -466,7 +467,7 @@ fun BoxScope.QueueContent(
         combine(snapshotFlow { qb.masterQueues.toList() }, playerConnection.service.qbInit) { updatedList, init ->
             updatedList to init
         }.collect { (updatedList, init) ->
-            Log.d("Queue.kt", "Trigger loading queue. init = $init")
+            if (PLAYER_DEBUG) Log.d("Queue.kt", "Trigger loading queue. init = $init")
             if (init) {
                 mutableQueues.clear()
                 mutableQueues.addAll(qb.getAllQueues())
@@ -476,7 +477,7 @@ fun BoxScope.QueueContent(
     }
 
     val queueHeader: @Composable ColumnScope.(Modifier) -> Unit = { modifier ->
-        Log.v("QueueContent", "QC-mq_a")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-mq_a")
 
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -519,7 +520,7 @@ fun BoxScope.QueueContent(
     }
 
     val queueList: @Composable ColumnScope.(PaddingValues) -> Unit = { contentPadding ->
-        Log.v("QueueContent", "QC-mq_b")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-mq_b")
         LaunchedEffect(mqExpand) { // scroll to queue
             if (mqExpand && playingQueue >= 0) {
                 lazyQueuesListState.animateScrollToItem(playingQueue)
@@ -633,7 +634,7 @@ fun BoxScope.QueueContent(
     }
 
     val songHeader: @Composable ColumnScope.(Modifier) -> Unit = { modifier ->
-        Log.v("QueueContent", "QC-s_a")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-s_a")
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -677,7 +678,7 @@ fun BoxScope.QueueContent(
     }
 
     val songList: @Composable ColumnScope.(PaddingValues) -> Unit = { contentPadding ->
-        Log.v("QueueContent", "QC-s_b")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-s_b")
         LazyColumn(
             state = lazySongsListState,
             contentPadding = contentPadding,
@@ -841,7 +842,7 @@ fun BoxScope.QueueContent(
     }
 
     val searchBar: @Composable ColumnScope.() -> Unit = {
-        Log.v("QueueContent", "QC-searchbar")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-searchbar")
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -889,7 +890,7 @@ fun BoxScope.QueueContent(
 
 // queue info + player controls
     val bottomNav: @Composable ColumnScope.() -> Unit = {
-        Log.v("QueueContent", "QC-nav")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-nav")
 
         Column(
             modifier = Modifier
@@ -1188,24 +1189,24 @@ fun BoxScope.QueueContent(
             }
         }
     } else {
-        Log.v("QueueContent", "QC-2.1")
+        if (PLAYER_DEBUG) Log.v("QueueContent", "QC-2.1")
         // queue contents
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxSize()
         ) {
-            Log.v("QueueContent", "QC-2.2")
+            if (PLAYER_DEBUG) Log.v("QueueContent", "QC-2.2")
             Column(
                 modifier = Modifier.weight(1f, false)
             ) {
-                Log.v("QueueContent", "QC-2.3")
+                if (PLAYER_DEBUG) Log.v("QueueContent", "QC-2.3")
                 // multiqueue list
                 AnimatedVisibility(
                     visible = isSearching,
                     modifier = Modifier
                         .windowInsetsPadding(InsetsSafeT)
                 ) {
-                    Log.v("QueueContent", "QC-2.4a")
+                    if (PLAYER_DEBUG) Log.v("QueueContent", "QC-2.4a")
                     Spacer(Modifier.windowInsetsPadding(InsetsSafeT))
                     searchBar()
                     if (inSelectMode) {
@@ -1229,7 +1230,7 @@ fun BoxScope.QueueContent(
                 }
 
                 AnimatedVisibility(mqExpand && !isSearching) {
-                    Log.v("QueueContent", "QC-2.4b")
+                    if (PLAYER_DEBUG) Log.v("QueueContent", "QC-2.4b")
                     // why cant i just put everything in one column???
                     Column {
                         Column(

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/PlayerScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/PlayerScreen.kt
@@ -3,6 +3,7 @@ package com.dd3boh.outertune.ui.screens
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
@@ -74,7 +75,7 @@ fun PlayerScreen(
             showLyrics = showLyrics,
             useDarkTheme = useDarkTheme,
         )
-        Log.v(TAG, "PLR-3.0")
+        if (UI_DEBUG) Log.v(TAG, "PLR-3.0")
 
         val state = rememberBottomSheetState(
             dismissedBound = 0.dp,

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/FolderScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/FolderScreen.kt
@@ -2,6 +2,7 @@ package com.dd3boh.outertune.ui.screens.library
 
 import android.content.pm.PackageManager
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -135,7 +136,7 @@ fun FolderScreen(
     isRoot: Boolean = false,
     libraryFilterContent: @Composable (() -> Unit)? = null
 ) {
-    Log.v("FolderScreen", "F_RC-1")
+    if (UI_DEBUG) Log.v("FolderScreen", "F_RC-1")
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -2,6 +2,7 @@ package com.dd3boh.outertune.ui.screens.library
 
 import android.content.pm.PackageManager
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -100,7 +101,7 @@ fun LibraryPlaylistsScreen(
     viewModel: LibraryPlaylistsViewModel = hiltViewModel(),
     libraryFilterContent: @Composable() (() -> Unit)? = null,
 ) {
-    Log.v("LibraryPlaylistsScreen", "LP_RC-1")
+    if (UI_DEBUG) Log.v("LibraryPlaylistsScreen", "LP_RC-1")
     val context = LocalContext.current
     val menuState = LocalMenuState.current
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibrarySongsScreen.kt
@@ -2,6 +2,7 @@ package com.dd3boh.outertune.ui.screens.library
 
 import android.content.pm.PackageManager
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -97,7 +98,7 @@ fun LibrarySongsScreen(
     viewModel: LibrarySongsViewModel = hiltViewModel(),
     libraryFilterContent: @Composable (() -> Unit)? = null
 ) {
-    Log.v("LibrarySongsScreen", "S_RC-1")
+    if (UI_DEBUG) Log.v("LibrarySongsScreen", "S_RC-1")
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.ui.screens.playlist
 
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -153,7 +154,7 @@ fun LocalPlaylistScreen(
     scrollBehavior: TopAppBarScrollBehavior,
     viewModel: LocalPlaylistViewModel = hiltViewModel(),
 ) {
-    Log.v("LocalPlaylistScreen", "P_RC-1")
+    if (UI_DEBUG) Log.v("LocalPlaylistScreen", "P_RC-1")
     val context = LocalContext.current
     val density = LocalDensity.current
     val menuState = LocalMenuState.current
@@ -433,14 +434,14 @@ fun LocalPlaylistScreen(
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        Log.v("LocalPlaylistScreen", "P_RC-2.1")
+        if (UI_DEBUG) Log.v("LocalPlaylistScreen", "P_RC-2.1")
         ScrollToTopManager(navController, lazyListState)
         LazyColumn(
             state = lazyListState,
             contentPadding = LocalPlayerAwareWindowInsets.current.union(WindowInsets.ime).asPaddingValues(),
             modifier = Modifier.padding(bottom = if (inSelectMode) 64.dp else 0.dp)
         ) {
-            Log.v("LocalPlaylistScreen", "P_RC-2.2")
+            if (UI_DEBUG) Log.v("LocalPlaylistScreen", "P_RC-2.2")
             playlistWithSongs.first?.let { playlist ->
                 if (playlist.songCount == 0) {
                     item {
@@ -672,7 +673,7 @@ fun LocalPlaylistHeader(
     snackbarHostState: SnackbarHostState,
     modifier: Modifier,
 ) {
-    Log.v("LocalPlaylistScreen", "P_H_RC-1")
+    if (UI_DEBUG) Log.v("LocalPlaylistScreen", "P_H_RC-1")
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
     val database = LocalDatabase.current

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.ui.screens.search
 
 import android.util.Log
+import com.dd3boh.outertune.constants.UI_DEBUG
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.fadeIn
@@ -77,7 +78,7 @@ fun SearchBarContainer(
     navController: NavController,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
-    Log.v("SearchBarContainer", "SB-1")
+    if (UI_DEBUG) Log.v("SearchBarContainer", "SB-1")
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val database = LocalDatabase.current
@@ -261,7 +262,7 @@ fun SearchBarContainer(
             windowInsets = searchBarInset,
             focusRequester = searchBarFocusRequester,
         ) {
-            Log.v("SearchBarContainer", "SB-2")
+            if (UI_DEBUG) Log.v("SearchBarContainer", "SB-2")
             Crossfade(
                 targetState = searchSource,
                 label = "",

--- a/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.util.Log
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import com.dd3boh.outertune.constants.SYNC_DEBUG
 import com.dd3boh.outertune.constants.LastAlbumSyncKey
 import com.dd3boh.outertune.constants.LastArtistSyncKey
 import com.dd3boh.outertune.constants.LastFullSyncKey
@@ -95,12 +96,12 @@ class SyncUtils @Inject constructor(
         if (!context.isAutoSyncEnabled()) {
             return
         }
-        Log.d(TAG, "Starting auto sync job")
+        if (SYNC_DEBUG) Log.d(TAG, "Starting auto sync job")
         if (!bypassCd) {
             val lastSync = context.dataStore.get(LastFullSyncKey, LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
             val currentTime = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             if (currentTime - lastSync > SYNC_CD) {
-                Log.d(TAG, "Aborting auto sync. ${(currentTime - lastSync) * 60000} minutes until eligible")
+                if (SYNC_DEBUG) Log.d(TAG, "Aborting auto sync. ${(currentTime - lastSync) * 60000} minutes until eligible")
                 return
             }
         }
@@ -123,7 +124,7 @@ class SyncUtils @Inject constructor(
         val lastSync = context.dataStore.get(key, LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
         val currentTime = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
         if (currentTime - lastSync > SYNC_CD) {
-            Log.d(TAG, "Aborting auto sync. ${(currentTime - lastSync) * 60000} minutes until eligible")
+            if (SYNC_DEBUG) Log.d(TAG, "Aborting auto sync. ${(currentTime - lastSync) * 60000} minutes until eligible")
             return false
         }
         return true
@@ -161,7 +162,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRemoteLikedSongs.value && (!checkEnabled(SyncContent.LIKED_SONGS) || !context.isInternetConnected())) {
             if (_isSyncingRemoteLikedSongs.value)
-                Log.i(TAG, "Library songs synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -173,7 +174,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRemoteLikedSongs.value = true
 
         try {
-            Log.d(TAG, "Liked songs synchronization started")
+            if (SYNC_DEBUG) Log.d(TAG, "Liked songs synchronization started")
 
             // Get remote and local liked songs
             YouTube.playlist("LM").completed().onSuccess { page ->
@@ -214,7 +215,7 @@ class SyncUtils @Inject constructor(
             context.dataStore.edit { settings ->
                 settings[LastLikeSongSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
-            Log.i(TAG, "Liked songs synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Liked songs synchronization ended")
             _isSyncingRemoteLikedSongs.value = false
         }
     }
@@ -226,7 +227,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRemoteSongs.value && (!checkEnabled(SyncContent.PRIVATE_SONGS) || !context.isInternetConnected())) {
             if (_isSyncingRemoteSongs.value)
-                Log.i(TAG, "Library songs synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -238,7 +239,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRemoteSongs.value = true
 
         try {
-            Log.i(TAG, "Library songs synchronization started")
+            if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization started")
 
             // Get remote songs (from library and uploads)
             val remoteSongs = getRemoteData<SongItem>("FEmusic_liked_videos", "FEmusic_library_privately_owned_tracks")
@@ -282,7 +283,7 @@ class SyncUtils @Inject constructor(
             context.dataStore.edit { settings ->
                 settings[LastLibSongSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
-            Log.i(TAG, "Library songs synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization ended")
             _isSyncingRemoteSongs.value = false
         }
     }
@@ -294,7 +295,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRemoteAlbums.value && (!checkEnabled(SyncContent.ALBUMS) || !context.isInternetConnected())) {
             if (_isSyncingRemoteAlbums.value)
-                Log.i(TAG, "Library songs synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -306,7 +307,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRemoteAlbums.value = true
 
         try {
-            Log.i(TAG, "Library albums synchronization started")
+            if (SYNC_DEBUG) Log.i(TAG, "Library albums synchronization started")
 
             // Get remote albums (from library and uploads)
             val remoteAlbums =
@@ -351,7 +352,7 @@ class SyncUtils @Inject constructor(
             context.dataStore.edit { settings ->
                 settings[LastAlbumSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
-            Log.i(TAG, "Library albums synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Library albums synchronization ended")
             _isSyncingRemoteAlbums.value = false // Use the correct AtomicBoolean
         }
     }
@@ -363,7 +364,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRemoteArtists.value && (!checkEnabled(SyncContent.ARTISTS) || !context.isInternetConnected())) {
             if (_isSyncingRemoteArtists.value)
-                Log.i(TAG, "Library songs synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -375,7 +376,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRemoteArtists.value = true
 
         try {
-            Log.i(TAG, "Artist subscriptions synchronization started")
+            if (SYNC_DEBUG) Log.i(TAG, "Artist subscriptions synchronization started")
 
             // Get remote artists (from library and uploads)
             val likedArtists = getRemoteData<ArtistItem>(
@@ -442,7 +443,7 @@ class SyncUtils @Inject constructor(
             context.dataStore.edit { settings ->
                 settings[LastArtistSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
-            Log.i(TAG, "Artist subscriptions synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Artist subscriptions synchronization ended")
             _isSyncingRemoteArtists.value = false
         }
     }
@@ -454,7 +455,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRemotePlaylists.value && (!checkEnabled(SyncContent.PLAYLISTS) || !context.isInternetConnected())) {
             if (_isSyncingRemotePlaylists.value)
-                Log.i(TAG, "Library songs synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Library songs synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -466,7 +467,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRemotePlaylists.value = true
 
         try {
-            Log.i(TAG, "Library playlist synchronization started")
+            if (SYNC_DEBUG) Log.i(TAG, "Library playlist synchronization started")
 
             // Get remote and local playlists
             YouTube.library("FEmusic_liked_playlists").completed().onSuccess { page ->
@@ -542,7 +543,7 @@ class SyncUtils @Inject constructor(
                 settings[LastPlaylistSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
             _isSyncingRemotePlaylists.value = false
-            Log.i(TAG, "Library playlist synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Library playlist synchronization ended")
         }
     }
 
@@ -583,7 +584,7 @@ class SyncUtils @Inject constructor(
         // REQUIRED: internet, no ongoing sync, and category enabled
         if (!_isSyncingRecentActivity.value && (!checkEnabled(SyncContent.RECENT_ACTIVITY) || !context.isInternetConnected())) {
             if (_isSyncingRecentActivity.value)
-                Log.i(TAG, "Recent activity synchronization already in progress")
+                if (SYNC_DEBUG) Log.i(TAG, "Recent activity synchronization already in progress")
             return
         }
         // OPTIONAL: auto sync and cooldown
@@ -595,7 +596,7 @@ class SyncUtils @Inject constructor(
         _isSyncingRecentActivity.value = true
 
         try {
-            Log.i(TAG, "Recent activity synchronization started")
+            if (SYNC_DEBUG) Log.i(TAG, "Recent activity synchronization started")
             YouTube.libraryRecentActivity().onSuccess { page ->
                 val recentActivity = page.items.take(9).drop(1)
 
@@ -612,7 +613,7 @@ class SyncUtils @Inject constructor(
                 settings[LastRecentActivitySyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
             _isSyncingRecentActivity.value = false
-            Log.i(TAG, "Recent activity synchronization ended")
+            if (SYNC_DEBUG) Log.i(TAG, "Recent activity synchronization ended")
         }
     }
 

--- a/app/src/main/java/com/dd3boh/outertune/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/potoken/PoTokenGenerator.kt
@@ -3,6 +3,7 @@ package com.dd3boh.outertune.utils.potoken
 import android.util.Log
 import android.webkit.CookieManager
 import com.dd3boh.outertune.App
+import com.dd3boh.outertune.constants.POTOKEN_DEBUG
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -45,7 +46,7 @@ class PoTokenGenerator {
      * [PoTokenWebView.generatePoToken] was called
      */
     private suspend fun getWebClientPoToken(videoId: String, sessionId: String, forceRecreate: Boolean): PoTokenResult {
-        Log.d(TAG, "Web poToken requested: $videoId, $sessionId")
+        if (POTOKEN_DEBUG) Log.d(TAG, "Web poToken requested: $videoId, $sessionId")
 
         val (poTokenGenerator, streamingPot, hasBeenRecreated) =
             webPoTokenGenLock.withLock {
@@ -89,7 +90,7 @@ class PoTokenGenerator {
             }
         }
 
-        Log.d(TAG, "[$videoId] playerPot=$playerPot, streamingPot=$streamingPot")
+        if (POTOKEN_DEBUG) Log.d(TAG, "[$videoId] playerPot=$playerPot, streamingPot=$streamingPot")
 
         return PoTokenResult(playerPot, streamingPot)
     }

--- a/app/src/main/java/com/dd3boh/outertune/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/potoken/PoTokenWebView.kt
@@ -3,6 +3,7 @@ package com.dd3boh.outertune.utils.potoken
 import android.content.Context
 import android.util.Log
 import android.webkit.ConsoleMessage
+import com.dd3boh.outertune.constants.POTOKEN_DEBUG
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -84,7 +85,7 @@ class PoTokenWebView private constructor(
      * run it, and obtain an `integrityToken`.
      */
     private fun loadHtmlAndObtainBotguard() {
-        Log.d(TAG, "loadHtmlAndObtainBotguard() called")
+        if (POTOKEN_DEBUG) Log.d(TAG, "loadHtmlAndObtainBotguard() called")
 
         scope.launch(exceptionHandler) {
             val html = withContext(Dispatchers.IO) {
@@ -103,7 +104,7 @@ class PoTokenWebView private constructor(
      */
     @JavascriptInterface
     fun downloadAndRunBotguard() {
-        Log.d(TAG, "downloadAndRunBotguard() called")
+        if (POTOKEN_DEBUG) Log.d(TAG, "downloadAndRunBotguard() called")
 
         makeBotguardServiceRequest(
             "https://www.youtube.com/api/jnn/v1/Create",
@@ -145,19 +146,19 @@ class PoTokenWebView private constructor(
      */
     @JavascriptInterface
     fun onRunBotguardResult(botguardResponse: String) {
-        Log.d(TAG, "botguardResponse: $botguardResponse")
+        if (POTOKEN_DEBUG) Log.d(TAG, "botguardResponse: $botguardResponse")
         makeBotguardServiceRequest(
             "https://www.youtube.com/api/jnn/v1/GenerateIT",
             "[ \"$REQUEST_KEY\", \"$botguardResponse\" ]",
         ) { responseBody ->
-            Log.d(TAG, "GenerateIT response: $responseBody")
+            if (POTOKEN_DEBUG) Log.d(TAG, "GenerateIT response: $responseBody")
             val (integrityToken, expirationTimeInSeconds) = parseIntegrityTokenData(responseBody)
 
             // leave 10 minutes of margin just to be sure
             expirationInstant = Instant.now().plusSeconds(expirationTimeInSeconds).minus(10, ChronoUnit.MINUTES)
 
             webView.evaluateJavascript("this.integrityToken = $integrityToken") {
-                Log.d(TAG, "initialization finished, expiration=${expirationTimeInSeconds}s")
+                if (POTOKEN_DEBUG) Log.d(TAG, "initialization finished, expiration=${expirationTimeInSeconds}s")
                 continuation.resume(this)
             }
         }
@@ -168,7 +169,7 @@ class PoTokenWebView private constructor(
     suspend fun generatePoToken(identifier: String): String {
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { cont ->
-                Log.d(TAG, "generatePoToken() called with identifier $identifier")
+                if (POTOKEN_DEBUG) Log.d(TAG, "generatePoToken() called with identifier $identifier")
                 addPoTokenEmitter(identifier, cont)
                 webView.evaluateJavascript(
                     """try {
@@ -204,7 +205,7 @@ class PoTokenWebView private constructor(
      */
     @JavascriptInterface
     fun onObtainPoTokenResult(identifier: String, poTokenU8: String) {
-        Log.d(TAG, "Generated poToken (before decoding): identifier=$identifier poTokenU8=$poTokenU8")
+        if (POTOKEN_DEBUG) Log.d(TAG, "Generated poToken (before decoding): identifier=$identifier poTokenU8=$poTokenU8")
         val poToken = try {
             u8ToBase64(poTokenU8)
         } catch (t: Throwable) {
@@ -212,7 +213,7 @@ class PoTokenWebView private constructor(
             return
         }
 
-        Log.d(TAG, "Generated poToken: identifier=$identifier poToken=$poToken")
+        if (POTOKEN_DEBUG) Log.d(TAG, "Generated poToken: identifier=$identifier poToken=$poToken")
         popPoTokenContinuation(identifier)?.resume(poToken)
     }
 


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Add per-area debug flags to `Vars.kt` (`PLAYER_DEBUG`, `QUEUE_DEBUG`, `SYNC_DEBUG`, `DOWNLOAD_DEBUG`, `SERVICE_DEBUG`, `POTOKEN_DEBUG`, `UI_DEBUG`), all disabled by default.
- Wrap the always-on `Log.v`/`Log.d`/`Log.i` calls in these areas with the matching flag, so Logcat stays quiet during normal use and the logs can be re-enabled per area when investigating.
- Leave `Log.w`/`Log.e` untouched so warnings and errors are still reported by default.
- Covers the player and queue, library/account sync, downloads, the playback service, PoToken generation, and the folder, library, search, and local playlist screens.

### Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts.
