### PR TITLE
fix: default to FFmpeg fallback for the full flavor's audio decoder

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/Vars.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.constants
 
 import android.os.Build
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import com.dd3boh.outertune.BuildConfig
 
 /**
@@ -8,6 +9,20 @@ import com.dd3boh.outertune.BuildConfig
  */
 
 const val ENABLE_FFMETADATAEX = BuildConfig.FLAVOR == "full"
+
+/**
+ * Default audio decoder mode, depending on flavor.
+ *
+ * The "full" flavor bundles the FFmpeg decoders, so default to falling back to them for
+ * formats the system cannot decode (e.g. ALAC). The "core" flavor has no FFmpeg decoders,
+ * so it stays on system-only. This is read-time only and is never persisted, so an explicit
+ * user choice always wins and the shared preference is not polluted across flavors.
+ */
+val DEFAULT_AUDIO_DECODER = if (ENABLE_FFMETADATAEX) {
+    DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON
+} else {
+    DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF
+}
 
 
 /**

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -68,6 +68,7 @@ import com.dd3boh.outertune.MainActivity
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.SERVICE_DEBUG
 import com.dd3boh.outertune.constants.AudioDecoderKey
+import com.dd3boh.outertune.constants.DEFAULT_AUDIO_DECODER
 import com.dd3boh.outertune.constants.AudioGaplessOffloadKey
 import com.dd3boh.outertune.constants.AudioNormalizationKey
 import com.dd3boh.outertune.constants.AudioOffloadKey
@@ -218,7 +219,7 @@ class MusicService : MediaLibraryService(),
 
     private val normalizeFactor = MutableStateFlow(1f)
 
-    private val audioDecoder = dataStore.get(AudioDecoderKey, DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
+    private val audioDecoder = dataStore.get(AudioDecoderKey, DEFAULT_AUDIO_DECODER)
     private val isGaplessOffloadAllowed = dataStore.get(AudioGaplessOffloadKey, false)
     val playerVolume = MutableStateFlow(dataStore.get(PlayerVolumeKey, 1f).coerceIn(0f, 1f))
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
@@ -35,6 +35,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.navigation.NavController
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.AudioDecoderKey
+import com.dd3boh.outertune.constants.DEFAULT_AUDIO_DECODER
 import com.dd3boh.outertune.constants.ENABLE_FFMETADATAEX
 import com.dd3boh.outertune.constants.KeepAliveKey
 import com.dd3boh.outertune.constants.PersistentQueueKey
@@ -62,7 +63,7 @@ fun PlayerSettings(
 ) {
     val (audioDecoder, onAudioDecoderChange) = rememberPreference(
         key = AudioDecoderKey,
-        defaultValue = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF
+        defaultValue = DEFAULT_AUDIO_DECODER
     )
     val (keepAlive, onKeepAliveChange) = rememberPreference(key = KeepAliveKey, defaultValue = false)
     val (persistentQueue, onPersistentQueueChange) = rememberPreference(key = PersistentQueueKey, defaultValue = true)


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

The `full` flavor bundles the FFmpeg decoders, but the audio decoder preference defaulted to system-only (`EXTENSION_RENDERER_MODE_OFF`).
Because of this, files whose codec the system cannot decode (for example ALAC inside an `.m4a` container) played silently: the playback position kept advancing, but no audio decoder or `AudioTrack` was ever created, even though a usable FFmpeg decoder was already shipped in the build.

This PR introduces a flavor-dependent default, `DEFAULT_AUDIO_DECODER`:

- The `full` flavor now defaults to `EXTENSION_RENDERER_MODE_ON`, so the system decoders are used first and FFmpeg is used only as a fallback for formats the system cannot handle.
- The `core` flavor keeps `EXTENSION_RENDERER_MODE_OFF`, where no FFmpeg decoder is compiled in and the setting is hidden.

The default is applied only when the preference is read and is never written. An explicit user choice is therefore preserved, and the shared preference is not affected when switching between flavors that share the same application id.

### Before/After

- Before: on the `full` flavor with default settings, ALAC `.m4a` files played silently (position advancing, no sound).
- After: the same files play correctly out of the box, while common formats keep using the system decoders.

(No UI layout changes; only the default value of the existing "Audio decoder" preference.)

### Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
