### PR TITLE
fix: avoid NPEs in YouTube library/account info and reflect sign-in after login

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/LoginScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,6 +37,7 @@ import com.dd3boh.outertune.ui.utils.backToMain
 import com.dd3boh.outertune.utils.rememberPreference
 import com.dd3boh.outertune.utils.reportException
 import com.zionhuang.innertube.YouTube
+import com.zionhuang.innertube.utils.parseCookieString
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -52,6 +55,17 @@ fun LoginScreen(
     var accountEmail by rememberPreference(AccountEmailKey, "")
     var accountChannelHandle by rememberPreference(AccountChannelHandleKey, "")
 
+    // Once the cookie shows an established session, leave the login screen and return to the
+    // start destination (the main screen) automatically.
+    val isLoggedIn = remember(innerTubeCookie) {
+        "SAPISID" in parseCookieString(innerTubeCookie)
+    }
+    LaunchedEffect(isLoggedIn) {
+        if (isLoggedIn) {
+            navController.popBackStack(navController.graph.startDestinationId, false)
+        }
+    }
+
     var webView: WebView? = null
 
     AndroidView(
@@ -61,19 +75,30 @@ fun LoginScreen(
         factory = { context ->
             WebView(context).apply {
                 webViewClient = object : WebViewClient() {
+                    private var loginHandled = false
                     override fun onPageFinished(view: WebView, url: String?) {
                         loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
                         loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
 
                         if (url?.startsWith("https://music.youtube.com") == true) {
-                            innerTubeCookie = CookieManager.getInstance().getCookie(url)
-                            GlobalScope.launch {
-                                YouTube.accountInfo().onSuccess {
-                                    accountName = it.name
-                                    accountEmail = it.email.orEmpty()
-                                    accountChannelHandle = it.channelHandle.orEmpty()
-                                }.onFailure {
-                                    reportException(it)
+                            val cookie = CookieManager.getInstance().getCookie(url)
+                            innerTubeCookie = cookie
+
+                            // Act only once the cookie shows an established session, so accountInfo()
+                            // is not called during intermediate, not-yet-signed-in page loads.
+                            if (!loginHandled && "SAPISID" in parseCookieString(cookie)) {
+                                loginHandled = true
+                                // Apply the cookie synchronously so accountInfo() is authenticated
+                                // without waiting for the asynchronous DataStore collector in App.
+                                YouTube.cookie = cookie
+                                GlobalScope.launch {
+                                    YouTube.accountInfo().onSuccess {
+                                        accountName = it.name
+                                        accountEmail = it.email.orEmpty()
+                                        accountChannelHandle = it.channelHandle.orEmpty()
+                                    }.onFailure {
+                                        reportException(it)
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.dd3boh.outertune.viewmodels
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dd3boh.outertune.constants.InnerTubeCookieKey
 import com.dd3boh.outertune.constants.PlaylistFilter
 import com.dd3boh.outertune.constants.PlaylistSortType
 import com.dd3boh.outertune.db.MusicDatabase
@@ -11,6 +12,7 @@ import com.dd3boh.outertune.db.entities.LocalItem
 import com.dd3boh.outertune.db.entities.Song
 import com.dd3boh.outertune.models.SimilarRecommendation
 import com.dd3boh.outertune.utils.SyncUtils
+import com.dd3boh.outertune.utils.dataStore
 import com.dd3boh.outertune.utils.reportException
 import com.dd3boh.outertune.utils.syncCoroutine
 import com.zionhuang.innertube.YouTube
@@ -20,12 +22,16 @@ import com.zionhuang.innertube.models.YTItem
 import com.zionhuang.innertube.pages.ExplorePage
 import com.zionhuang.innertube.pages.HomePage
 import com.zionhuang.innertube.utils.completed
+import com.zionhuang.innertube.utils.parseCookieString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -201,6 +207,14 @@ class HomeViewModel @Inject constructor(
         refresh()
         viewModelScope.launch(syncCoroutine) {
             syncUtils.tryAutoSync()
+        }
+        // Reload when the sign-in state changes so the home reflects login without a manual refresh.
+        viewModelScope.launch {
+            context.dataStore.data
+                .map { "SAPISID" in parseCookieString(it[InnerTubeCookieKey] ?: "") }
+                .distinctUntilChanged()
+                .drop(1) // skip the current state already loaded by refresh() above
+                .collect { refresh() }
         }
     }
 }

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -555,10 +555,11 @@ object YouTube {
 
             else -> { // contents?.musicShelfRenderer != null
                 LibraryPage(
-                    items = contents?.musicShelfRenderer?.contents!!
-                        .mapNotNull (MusicShelfRenderer.Content::musicResponsiveListItemRenderer)
-                        .mapNotNull { LibraryPage.fromMusicResponsiveListItemRenderer(it) },
-                    continuation = contents.musicShelfRenderer.continuations?.getContinuation()
+                    items = contents?.musicShelfRenderer?.contents
+                        ?.mapNotNull (MusicShelfRenderer.Content::musicResponsiveListItemRenderer)
+                        ?.mapNotNull { LibraryPage.fromMusicResponsiveListItemRenderer(it) }
+                        .orEmpty(),
+                    continuation = contents?.musicShelfRenderer?.continuations?.getContinuation()
                 )
             }
         }
@@ -585,10 +586,11 @@ object YouTube {
 
             else -> { // contents?.musicShelfContinuation != null
                 LibraryContinuationPage(
-                    items = contents?.musicShelfContinuation?.contents!!
-                        .mapNotNull (MusicShelfRenderer.Content::musicResponsiveListItemRenderer)
-                        .mapNotNull { LibraryPage.fromMusicResponsiveListItemRenderer(it) },
-                    continuation = contents.musicShelfContinuation.continuations?.getContinuation()
+                    items = contents?.musicShelfContinuation?.contents
+                        ?.mapNotNull (MusicShelfRenderer.Content::musicResponsiveListItemRenderer)
+                        ?.mapNotNull { LibraryPage.fromMusicResponsiveListItemRenderer(it) }
+                        .orEmpty(),
+                    continuation = contents?.musicShelfContinuation?.continuations?.getContinuation()
                 )
             }
         }
@@ -884,7 +886,8 @@ object YouTube {
         innerTube.accountMenu(WEB_REMIX).body<AccountMenuResponse>()
             .actions[0].openPopupAction.popup.multiPageMenuRenderer
             .header?.activeAccountHeaderRenderer
-            ?.toAccountInfo()!!
+            ?.toAccountInfo()
+            ?: throw IllegalStateException("Account info is not available (not signed in or account header missing)")
     }
 
     @JvmInline


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Two related changes around login and library handling.

**Avoid NullPointerException for expected empty responses in YouTube (innertube)**

`library`, `libraryContinuation`, and `accountInfo` used non-null assertions on data that is legitimately absent in normal situations, such as when the user is not signed in. The assertions threw `NullPointerException`, which `runCatching` captured and `reportException` then printed to `System.err` as a stack trace, even though these are expected states rather than errors.

- `library` / `libraryContinuation`: return an empty page when the browse response has neither a grid nor a music shelf.
- `accountInfo`: throw a descriptive `IllegalStateException` when the account header is missing, instead of a `NullPointerException`.

**Reflect sign-in after login without a manual refresh (app)**

After signing in, the login WebView stayed on screen and did not return to the main screen on its own, and the home kept showing the signed-out state until a manual refresh. `accountInfo()` was also called during intermediate, not-yet-signed-in page loads and reported exceptions to `System.err`.

- `HomeViewModel`: observe the sign-in state and reload when it changes, so the home reflects login without a manual refresh.
- `LoginScreen`: return to the start destination automatically once signed in, because the flat navigation graph made `backToMain` stop one screen short of the main screen.
- `LoginScreen`: call `accountInfo()` only once the cookie shows an established session, and apply the cookie synchronously so the request is authenticated instead of racing the asynchronous cookie collector in `App`; this avoids the exceptions logged to `System.err`.

### Before/After Screenshots/Screen Record

Behavioral change (automatic return to the main screen after login, and the home reflecting sign-in without a manual refresh); there is no static UI element to screenshot.

### Fixes the following issue(s)

- No tracked issue; found and verified on a device.

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the merger to modify my code to solve merge conflicts.
