### PR TITLE
fix: correct album song count shown on album screen

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
@@ -209,7 +209,7 @@ interface DatabaseDao : SongsDao, AlbumsDao, ArtistsDao, PlaylistsDao, QueueDao 
                     id = albumId,
                     title = it.title,
                     thumbnailUrl = album?.thumbnailUrl?: mediaMetadata.thumbnailUrl,
-                    songCount = 1,
+                    songCount = (album?.songCount ?: 0).coerceAtLeast(1),
                     duration = (album?.duration ?: 0) + mediaMetadata.duration,
                     isLocal = it.isLocal
                 )

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/AlbumViewModel.kt
@@ -33,7 +33,7 @@ class AlbumViewModel @Inject constructor(
             val album = database.album(albumId).first()
             if (album?.album?.isLocal == true) return@launch
             YouTube.album(albumId).onSuccess {
-                if (album == null || album.album.songCount == 0) {
+                if (album == null || album.album.songCount != it.songs.size) {
                     database.transaction {
                         if (album == null) insert(it)
                         else update(album.album, it)


### PR DESCRIPTION
### What is it?

- [x] Bugfix (user facing)

### Description of the changes in your PR

`insert(albumPage)` sets `AlbumEntity.songCount` to the correct track count from the YouTube response.
However, it then calls `insert(mediaMetadata)` for each track,
which upserted the album with a hardcoded `songCount = 1`, overwriting the correct value.
`AlbumViewModel` skipped the refresh because its update condition only triggered when `songCount == 0`,
so the stale value of `1` persisted on subsequent visits to the album screen.

- `DatabaseDao`: when upserting from `MediaMetadata`, preserve the existing `songCount`
  instead of overwriting with a hardcoded `1` (`coerceAtLeast(1)`)
- `AlbumViewModel`: trigger a DB update whenever the stored count differs
  from the YouTube-fetched count (`songCount != it.songs.size`)

### Before/After Screenshots/Screen Record

- Before: album subtitle shows "1 song" regardless of actual track count

<img width="270" height="600" alt="SS05" src="https://github.com/user-attachments/assets/e96a0629-b56c-4dc6-a356-6209ed9ce60b" />


- After: album subtitle shows the correct number of tracks (e.g. "8 songs")

<img width="270" height="600" alt="Screenshot_20260620_163748" src="https://github.com/user-attachments/assets/dc53afb4-f56e-442d-b394-f4cd4947049d" />


### Fixes the following issue(s)

- Fixes #34

### Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed