### PR TITLE
Replace manual high contrast toggle with automatic system detection

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -115,7 +115,6 @@ import com.dd3boh.outertune.constants.DarkModeKey
 import com.dd3boh.outertune.constants.DefaultOpenTabKey
 import com.dd3boh.outertune.constants.DynamicThemeKey
 import com.dd3boh.outertune.constants.EnabledTabsKey
-import com.dd3boh.outertune.constants.HighContrastKey
 import com.dd3boh.outertune.constants.LibraryFilterKey
 import com.dd3boh.outertune.constants.MinMiniPlayerHeight
 import com.dd3boh.outertune.constants.MiniPlayerHeight
@@ -259,7 +258,6 @@ class MainActivity : ComponentActivity() {
 
             val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = true)
             val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
-            val highContrastCompat by rememberPreference(HighContrastKey, defaultValue = false)
             val pureBlack by rememberPreference(PureBlackKey, defaultValue = false)
             val isSystemInDarkTheme = isSystemInDarkTheme()
             val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {
@@ -321,7 +319,6 @@ class MainActivity : ComponentActivity() {
                 isSystemInDarkTheme = isSystemInDarkTheme,
                 darkTheme = useDarkTheme,
                 pureBlack = pureBlack,
-                highContrastCompat = highContrastCompat,
             ) {
                 if (UI_DEBUG) Log.v(MAIN_TAG, "RC-2.1")
                 val density = LocalDensity.current

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -10,7 +10,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
  * Appearance
  */
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
-val HighContrastKey = booleanPreferencesKey("highContrast")
 val PlayerBackgroundStyleKey = stringPreferencesKey("playerBackgroundStyle")
 val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/ThemeFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/ThemeFrag.kt
@@ -9,7 +9,6 @@
 package com.dd3boh.outertune.ui.screens.settings.fragments
 
 import android.os.Build
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.BlurOn
@@ -25,7 +24,6 @@ import com.dd3boh.outertune.constants.DEFAULT_PLAYER_BACKGROUND
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
 import com.dd3boh.outertune.constants.DynamicThemeKey
-import com.dd3boh.outertune.constants.HighContrastKey
 import com.dd3boh.outertune.constants.PlayerBackgroundStyle
 import com.dd3boh.outertune.constants.PlayerBackgroundStyleKey
 import com.dd3boh.outertune.constants.PureBlackKey
@@ -40,7 +38,6 @@ import androidx.compose.ui.tooling.preview.Preview
 fun ColumnScope.ThemeAppFrag() {
     val (darkMode, onDarkModeChange) = rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
     val (dynamicTheme, onDynamicThemeChange) = rememberPreference(DynamicThemeKey, defaultValue = true)
-    val (highContrastCompat, onHccChange) = rememberPreference(HighContrastKey, defaultValue = false)
 
     val (pureBlack, onPureBlackChange) = rememberPreference(PureBlackKey, defaultValue = false)
 
@@ -50,15 +47,6 @@ fun ColumnScope.ThemeAppFrag() {
         checked = dynamicTheme,
         onCheckedChange = onDynamicThemeChange
     )
-    AnimatedVisibility(!dynamicTheme) {
-        SwitchPreference(
-            title = { Text(stringResource(R.string.high_contrast)) },
-            description = stringResource(R.string.high_contrast_description),
-            icon = { Icon(Icons.Rounded.Contrast, null) },
-            checked = highContrastCompat,
-            onCheckedChange = onHccChange
-        )
-    }
     EnumListPreference(
         title = { Text(stringResource(R.string.dark_theme)) },
         icon = { Icon(Icons.Rounded.DarkMode, null) },

--- a/app/src/main/java/com/dd3boh/outertune/ui/theme/Theme.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/theme/Theme.kt
@@ -8,6 +8,7 @@
  */
 package com.dd3boh.outertune.ui.theme
 
+import android.app.UiModeManager
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Build
@@ -17,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +28,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
@@ -56,10 +59,10 @@ fun OuterTuneTheme(
     isSystemInDarkTheme: Boolean,
     darkTheme: Boolean = isSystemInDarkTheme(),
     pureBlack: Boolean = false,
-    highContrastCompat: Boolean,
     content: @Composable () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val highContrast = rememberSystemHighContrast(context)
 
     var themeColor by rememberSaveable(stateSaver = ColorSaver) {
         mutableStateOf(DefaultThemeColor)
@@ -99,7 +102,7 @@ fun OuterTuneTheme(
     }
 
 
-    val colorScheme = remember(darkTheme, pureBlack, themeColor) {
+    val colorScheme = remember(darkTheme, pureBlack, themeColor, highContrast) {
        if (themeColor == DefaultThemeColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val systemTheme = if (darkTheme) {
                 dynamicDarkColorScheme(context).pureBlack(pureBlack)
@@ -111,7 +114,7 @@ fun OuterTuneTheme(
             // when high contrast mode Android collapses all accent colours into (more or less) one shade. We use
             // secondaryContainer and onSecondaryContainer weirdly in several places in terms of theming so just replace
             // those with shades that make sense
-            if (highContrastCompat) {
+            if (highContrast) {
                 systemTheme.copy(
                     secondaryContainer = systemTheme.surfaceContainerHigh,
                     onSecondaryContainer = systemTheme.secondary,
@@ -131,6 +134,36 @@ fun OuterTuneTheme(
         typography = MaterialTheme.typography,
         content = content
     )
+}
+
+/**
+ * Detects whether Android's system contrast is set to medium or higher and keeps it up to date.
+ *
+ * The contrast setting and its change listener are only available on API 34+; on older versions
+ * (which have no such setting) this always returns false.
+ */
+@Composable
+fun rememberSystemHighContrast(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return false
+    }
+
+    val uiModeManager = remember(context) {
+        context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+    }
+    var highContrast by remember { mutableStateOf(uiModeManager.contrast >= 0.5f) }
+
+    DisposableEffect(uiModeManager) {
+        val listener = UiModeManager.ContrastChangeListener { contrast ->
+            highContrast = contrast >= 0.5f
+        }
+        uiModeManager.addContrastChangeListener(ContextCompat.getMainExecutor(context), listener)
+        onDispose {
+            uiModeManager.removeContrastChangeListener(listener)
+        }
+    }
+
+    return highContrast
 }
 
 fun Bitmap.extractThemeColor(): Color {

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -121,8 +121,6 @@ while also allowing users to translate our app as well. New, specific strings to
 
 <!-- Appearance settings -->
     <string name="new_interface">New interface layout</string>
-    <string name="high_contrast" translatable="false">High contrast mode compatibility</string>
-    <string name="high_contrast_description" translatable="false">Enable to fix some visual issues when Android\'s high contrast mode is enabled</string>
     <string name="player_background_blur">Blur</string>
     <string name="player_background_default">Follow theme</string>
     <string name="player_background_gradient">Gradient</string>


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Detect Android's system contrast through `UiModeManager.getContrast()` and apply the high contrast color adjustments automatically when the system contrast is medium or higher (`>= 0.5`).
- Keep the value up to date at runtime through a contrast change listener registered with a `DisposableEffect`, so toggling the system contrast setting is reflected without restarting the app.
- Remove the manual "High contrast mode compatibility" toggle, its preference key, and its description strings, since the behavior is now derived from the system setting.
- Detection relies on APIs available on API 34+. On older versions, which have no system contrast setting, no adjustment is applied.

### Before/After Screenshots/Screen Record

- Before: the high contrast color adjustments were controlled by a manual toggle under Appearance (shown only when the dynamic theme was off), which defaulted to off.
- After: the toggle is removed, and the adjustments are applied automatically when the system contrast is medium or higher, updating when the system setting changes.

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
