### PR TITLE
Add custom accent color with preset palette

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -110,6 +110,8 @@ import androidx.navigation.navArgument
 import androidx.window.core.layout.WindowSizeClass
 import com.dd3boh.outertune.constants.AppBarHeight
 import com.dd3boh.outertune.constants.DEFAULT_ENABLED_TABS
+import com.dd3boh.outertune.constants.CustomThemeColorKey
+import com.dd3boh.outertune.constants.CustomThemeKey
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
 import com.dd3boh.outertune.constants.DefaultOpenTabKey
@@ -177,6 +179,7 @@ import com.dd3boh.outertune.ui.screens.settings.LyricsSettings
 import com.dd3boh.outertune.ui.screens.settings.PlayerSettings
 import com.dd3boh.outertune.ui.screens.settings.SettingsScreen
 import com.dd3boh.outertune.ui.screens.settings.StorageSettings
+import com.dd3boh.outertune.ui.theme.DefaultThemeColor
 import com.dd3boh.outertune.ui.theme.OuterTuneTheme
 import com.dd3boh.outertune.ui.utils.appBarScrollBehavior
 import com.dd3boh.outertune.utils.ActivityLauncherHelper
@@ -257,6 +260,8 @@ class MainActivity : ComponentActivity() {
             val snackbarHostState = remember { SnackbarHostState() }
 
             val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = true)
+            val customTheme by rememberPreference(CustomThemeKey, defaultValue = false)
+            val customThemeColorArgb by rememberPreference(CustomThemeColorKey, defaultValue = DefaultThemeColor.toArgb())
             val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
             val pureBlack by rememberPreference(PureBlackKey, defaultValue = false)
             val isSystemInDarkTheme = isSystemInDarkTheme()
@@ -319,6 +324,8 @@ class MainActivity : ComponentActivity() {
                 isSystemInDarkTheme = isSystemInDarkTheme,
                 darkTheme = useDarkTheme,
                 pureBlack = pureBlack,
+                customTheme = customTheme,
+                customThemeColor = Color(customThemeColorArgb),
             ) {
                 if (UI_DEBUG) Log.v(MAIN_TAG, "RC-2.1")
                 val density = LocalDensity.current

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -10,6 +10,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
  * Appearance
  */
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
+val CustomThemeKey = booleanPreferencesKey("customTheme")
+val CustomThemeColorKey = intPreferencesKey("customThemeColor")
 val PlayerBackgroundStyleKey = stringPreferencesKey("playerBackgroundStyle")
 val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/ThemeFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/ThemeFrag.kt
@@ -9,17 +9,43 @@
 package com.dd3boh.outertune.ui.screens.settings.fragments
 
 import android.os.Build
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.BlurOn
+import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.Contrast
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.dd3boh.outertune.R
+import com.dd3boh.outertune.constants.CustomThemeColorKey
+import com.dd3boh.outertune.constants.CustomThemeKey
 import com.dd3boh.outertune.constants.DEFAULT_PLAYER_BACKGROUND
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
@@ -28,7 +54,11 @@ import com.dd3boh.outertune.constants.PlayerBackgroundStyle
 import com.dd3boh.outertune.constants.PlayerBackgroundStyleKey
 import com.dd3boh.outertune.constants.PureBlackKey
 import com.dd3boh.outertune.ui.component.EnumListPreference
+import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.SwitchPreference
+import com.dd3boh.outertune.ui.dialog.ActionPromptDialog
+import com.dd3boh.outertune.ui.theme.DefaultThemeColor
+import com.dd3boh.outertune.ui.theme.PresetThemeColors
 import com.dd3boh.outertune.utils.rememberEnumPreference
 import com.dd3boh.outertune.utils.rememberPreference
 import androidx.compose.foundation.layout.Column
@@ -38,15 +68,53 @@ import androidx.compose.ui.tooling.preview.Preview
 fun ColumnScope.ThemeAppFrag() {
     val (darkMode, onDarkModeChange) = rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
     val (dynamicTheme, onDynamicThemeChange) = rememberPreference(DynamicThemeKey, defaultValue = true)
+    val (customTheme, onCustomThemeChange) = rememberPreference(CustomThemeKey, defaultValue = false)
+    val (customThemeColor, onCustomThemeColorChange) = rememberPreference(
+        CustomThemeColorKey,
+        defaultValue = DefaultThemeColor.toArgb()
+    )
 
     val (pureBlack, onPureBlackChange) = rememberPreference(PureBlackKey, defaultValue = false)
 
+    var showColorPicker by rememberSaveable { mutableStateOf(false) }
+
+    // Dynamic theme and a custom accent color are mutually exclusive: enabling one disables the
+    // other so both toggles stay visible without items appearing or disappearing unexpectedly.
     SwitchPreference(
         title = { Text(stringResource(R.string.enable_dynamic_theme)) },
         icon = { Icon(Icons.Rounded.Palette, null) },
         checked = dynamicTheme,
-        onCheckedChange = onDynamicThemeChange
+        onCheckedChange = { checked ->
+            onDynamicThemeChange(checked)
+            if (checked) onCustomThemeChange(false)
+        }
     )
+    SwitchPreference(
+        title = { Text(stringResource(R.string.custom_accent_color)) },
+        description = stringResource(R.string.custom_accent_color_description),
+        icon = { Icon(Icons.Rounded.ColorLens, null) },
+        checked = customTheme,
+        onCheckedChange = { checked ->
+            onCustomThemeChange(checked)
+            if (checked) onDynamicThemeChange(false)
+        }
+    )
+    AnimatedVisibility(customTheme) {
+        PreferenceEntry(
+            title = { Text(stringResource(R.string.accent_color)) },
+            icon = { Icon(Icons.Rounded.Palette, null) },
+            trailingContent = {
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                        .background(Color(customThemeColor))
+                        .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                )
+            },
+            onClick = { showColorPicker = true }
+        )
+    }
     EnumListPreference(
         title = { Text(stringResource(R.string.dark_theme)) },
         icon = { Icon(Icons.Rounded.DarkMode, null) },
@@ -66,6 +134,68 @@ fun ColumnScope.ThemeAppFrag() {
         checked = pureBlack,
         onCheckedChange = onPureBlackChange
     )
+
+    if (showColorPicker) {
+        AccentColorPickerDialog(
+            selectedColor = Color(customThemeColor),
+            onColorSelected = {
+                onCustomThemeColorChange(it.toArgb())
+                showColorPicker = false
+            },
+            onDismiss = { showColorPicker = false }
+        )
+    }
+}
+
+@Composable
+private fun AccentColorPickerDialog(
+    selectedColor: Color,
+    onColorSelected: (Color) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Store the in-progress selection as an argb Int so it survives configuration changes
+    // (Color has no default Saver).
+    var tempColorArgb by rememberSaveable { mutableStateOf(selectedColor.toArgb()) }
+    val tempColor = Color(tempColorArgb)
+
+    ActionPromptDialog(
+        title = stringResource(R.string.accent_color),
+        onDismiss = onDismiss,
+        onConfirm = { onColorSelected(tempColor) },
+        onCancel = onDismiss,
+    ) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(vertical = 8.dp)
+        ) {
+            PresetThemeColors.forEach { color ->
+                val isSelected = color == tempColor
+                val colorHex = String.format("#%06X", 0xFFFFFF and color.toArgb())
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(color)
+                        .border(
+                            width = if (isSelected) 3.dp else 1.dp,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.onSurface
+                            } else {
+                                MaterialTheme.colorScheme.outline
+                            },
+                            shape = CircleShape
+                        )
+                        .selectable(
+                            selected = isSelected,
+                            role = Role.RadioButton,
+                            onClick = { tempColorArgb = color.toArgb() }
+                        )
+                        .semantics { contentDescription = colorHex }
+                )
+            }
+        }
+    }
 }
 
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/theme/Theme.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/theme/Theme.kt
@@ -48,8 +48,25 @@ import com.google.material.color.score.Score
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-// TODO: support for custom accent
 val DefaultThemeColor = Color(0xFFED5564)
+
+// Preset accent colors the user can choose from. Each value is a seed color; the full Material3
+// color scheme is generated from it via SchemeTonalSpot.
+val PresetThemeColors = listOf(
+    Color(0xFFED5564), // red
+    Color(0xFFEC407A), // pink
+    Color(0xFFAB47BC), // purple
+    Color(0xFF7E57C2), // deep purple
+    Color(0xFF5C6BC0), // indigo
+    Color(0xFF42A5F5), // blue
+    Color(0xFF26C6DA), // cyan
+    Color(0xFF26A69A), // teal
+    Color(0xFF66BB6A), // green
+    Color(0xFF9CCC65), // lime
+    Color(0xFFFFCA28), // yellow
+    Color(0xFFFFA726), // orange
+    Color(0xFF8D6E63), // brown
+)
 
 @Composable
 fun OuterTuneTheme(
@@ -59,6 +76,8 @@ fun OuterTuneTheme(
     isSystemInDarkTheme: Boolean,
     darkTheme: Boolean = isSystemInDarkTheme(),
     pureBlack: Boolean = false,
+    customTheme: Boolean = false,
+    customThemeColor: Color = DefaultThemeColor,
     content: @Composable () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -68,7 +87,12 @@ fun OuterTuneTheme(
         mutableStateOf(DefaultThemeColor)
     }
 
-    LaunchedEffect(playerConnection, enableDynamicTheme, isSystemInDarkTheme) {
+    LaunchedEffect(playerConnection, enableDynamicTheme, isSystemInDarkTheme, customTheme, customThemeColor) {
+        // A user-selected accent color takes priority over artwork-based and system dynamic theming.
+        if (customTheme) {
+            themeColor = customThemeColor
+            return@LaunchedEffect
+        }
         val playerConnection = playerConnection
         if (!enableDynamicTheme || playerConnection == null) {
             themeColor = DefaultThemeColor
@@ -102,8 +126,10 @@ fun OuterTuneTheme(
     }
 
 
-    val colorScheme = remember(darkTheme, pureBlack, themeColor, highContrast) {
-       if (themeColor == DefaultThemeColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    val colorScheme = remember(darkTheme, pureBlack, themeColor, customTheme, highContrast) {
+       // When customTheme is on, always use SchemeTonalSpot even if the chosen color happens to
+       // equal DefaultThemeColor, so it does not fall through to the system Material You branch.
+       if (!customTheme && themeColor == DefaultThemeColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val systemTheme = if (darkTheme) {
                 dynamicDarkColorScheme(context).pureBlack(pureBlack)
             } else {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -174,6 +174,9 @@
     <string name="appearance">外観</string>
     <string name="theme">テーマ</string>
     <string name="enable_dynamic_theme">ダイナミックテーマを有効化</string>
+    <string name="custom_accent_color">カスタムアクセントカラー</string>
+    <string name="custom_accent_color_description">アプリ全体で、好みの色をアクセントカラーとして使用</string>
+    <string name="accent_color">アクセントカラー</string>
     <string name="dark_theme">ダークテーマ</string>
     <string name="dark_theme_on">オン</string>
     <string name="dark_theme_off">オフ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,9 @@ We recycle translations from upstream, they are pulled periodically. -->
     <string name="appearance">Appearance</string>
     <string name="theme">Theme</string>
     <string name="enable_dynamic_theme">Enable dynamic theme</string>
+    <string name="custom_accent_color">Custom accent color</string>
+    <string name="custom_accent_color_description">Use a fixed color of your choice as the accent throughout the app</string>
+    <string name="accent_color">Accent color</string>
     <string name="dark_theme">Dark theme</string>
     <string name="dark_theme_on">On</string>
     <string name="dark_theme_off">Off</string>


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Add an option in Appearance to choose a fixed accent color from a palette of 13 presets.
- When enabled, the chosen color is used as the app's accent instead of the color extracted from album art or the system (Material You) colors.
- The dynamic theme and custom accent color settings are mutually exclusive: enabling one disables the other, and both stay visible.
- The color is chosen from a dialog of preset swatches. Each swatch is exposed to screen readers with its hex value, and the in-progress selection is kept across configuration changes.

### Before/After Screenshots/Screen Record

- Before: Appearance offered the dynamic (album-art based) theme and the system colors, with no option to set a fixed accent color.
- After: a "Custom accent color" toggle and a color picker are available; when enabled, the selected preset color is used as the accent.

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
