### PR TITLE
fix(nav): stop screen flicker when tapping the already-active tab

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -809,16 +809,14 @@ class MainActivity : ComponentActivity() {
                                                     navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
                                                     scrollBehavior.state.heightOffset = 0f
                                                     scrollBehavior.state.contentOffset = 0f
-                                                }
-
-                                                if (screen.route == Screens.Home.route) {
+                                                } else if (screen.route == Screens.Home.route) {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
                                                             saveState = true
                                                         }
                                                         launchSingleTop = true
                                                     }
-                                                } else if (isCurrentTab || isInCurrentTabStack) {
+                                                } else if (isInCurrentTabStack) {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(screen.route)
                                                         launchSingleTop = true
@@ -921,16 +919,14 @@ class MainActivity : ComponentActivity() {
                                                     navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
                                                     scrollBehavior.state.heightOffset = 0f
                                                     scrollBehavior.state.contentOffset = 0f
-                                                }
-
-                                                if (screen.route == Screens.Home.route) {
+                                                } else if (screen.route == Screens.Home.route) {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
                                                             saveState = true
                                                         }
                                                         launchSingleTop = true
                                                     }
-                                                } else if (isCurrentTab || isInCurrentTabStack) {
+                                                } else if (isInCurrentTabStack) {
                                                     navController.navigate(screen.route) {
                                                         popUpTo(screen.route)
                                                         launchSingleTop = true


### PR DESCRIPTION
### What is it?

- [x] Bugfix (user facing)

### Description of the changes in your PR

- Tapping the navigation entry for the tab that is already open made the screen flicker.
- Cause: reselecting the active tab also re-navigated to the same tab, rebuilding the screen and replaying its transition.
- Fix: reselecting the active tab now only scrolls back to the top, without re-navigating.
- Switching to a different tab is unchanged.
- Covers both the phone navigation bar and the tablet navigation rail.

### Before/After Screenshots/Screen Record

- Before:
- After:

### Fixes the following issue(s)

- Fixes #

### Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed