### PR TITLE
fix(FolderScreen): change default sort to track number ascending

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/FolderScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/FolderScreen.kt
@@ -149,8 +149,8 @@ fun FolderScreen(
     val lastLocalScan by rememberPreference(LastLocalScanKey, 0L)
     val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
 
-    val (sortType, onSortTypeChange) = rememberEnumPreference(FolderSongSortTypeKey, FolderSongSortType.NAME)
-    val (sortDescending, onSortDescendingChange) = rememberPreference(FolderSongSortDescendingKey, true)
+    val (sortType, onSortTypeChange) = rememberEnumPreference(FolderSongSortTypeKey, FolderSongSortType.TRACK_NUMBER)
+    val (sortDescending, onSortDescendingChange) = rememberPreference(FolderSongSortDescendingKey, false)
     val (folderSortType, onFolderSortTypeChange) = rememberEnumPreference(FolderSortTypeKey, FolderSortType.NAME)
     val swipeEnabled by rememberPreference(SwipeToQueueKey, true)
 
@@ -195,6 +195,12 @@ fun FolderScreen(
 
     val mutableSongs = remember {
         mutableStateListOf<Song>()
+    }
+    val mutableSubdirs = remember {
+        mutableStateListOf<DirectoryTree>()
+    }
+    val mutableFlatSubdirs = remember {
+        mutableStateListOf<DirectoryTree>()
     }
 
     // search
@@ -255,11 +261,18 @@ fun FolderScreen(
 
         if (sortDescending) {
             newSubdirs.reverse()
-            currDir.subdirs.apply {
-                clear()
-                addAll(newSubdirs)
-            }
             tempList.reverse()
+        }
+
+        mutableSubdirs.apply {
+            clear()
+            addAll(newSubdirs)
+        }
+
+        val newFlatSubdirs = currDir.getFlattenedSubdirs().sortedBy { it.currentDir.lowercase() }
+        mutableFlatSubdirs.apply {
+            clear()
+            addAll(if (sortDescending) newFlatSubdirs.reversed() else newFlatSubdirs)
         }
 
         mutableSongs.apply {
@@ -455,7 +468,7 @@ fun FolderScreen(
 
                 // all subdirectories listed here
                 itemsIndexed(
-                    items = if (flatSubfolders) currDir.getFlattenedSubdirs() else currDir.subdirs,
+                    items = if (flatSubfolders) mutableFlatSubdirs else mutableSubdirs,
                     key = { _, item -> item.uid },
                     contentType = { _, _ -> CONTENT_TYPE_FOLDER }
                 ) { index, folder ->


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Change the default song sort in the folder tab from name order to track number ascending order.
- Fix a bug where changing the sort type or direction had no effect on the folder list.

The root causes of the sort bug were:

- The subdirectory list was only written back when `sortDescending` was `true`, so ascending order was never applied to subdirectories.
- `currDir.subdirs` is a plain `ArrayList`. Compose cannot detect in-place mutations, so changing the sort did not trigger recomposition.

To fix this, `mutableSubdirs` and `mutableFlatSubdirs` are introduced as `SnapshotStateList` instances. Both are populated unconditionally in the `LaunchedEffect` that reacts to `sortType`, `sortDescending`, and `currDir`, ensuring any sort change is reflected immediately.

### Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed