### PR TITLE
fix(ui): restore the search bar when returning to the Folders screen

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -155,8 +155,12 @@ fun SearchBarContainer(
         }
         val currentRoute = navBackStackEntry?.destination?.route
         previousRoute?.let { savedHeightOffsets[it] = scrollBehavior.state.heightOffset }
-        scrollBehavior.state.heightOffset = savedHeightOffsets[currentRoute] ?: 0f
-        scrollBehavior.state.contentOffset = 0f
+        if (currentRoute?.startsWith("${Screens.Folders.route}/") == true) {
+            savedHeightOffsets[Screens.Folders.route] = 0f
+        } else {
+            scrollBehavior.state.heightOffset = savedHeightOffsets[currentRoute] ?: 0f
+            scrollBehavior.state.contentOffset = 0f
+        }
         previousRoute = currentRoute
     }
 


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- On the Folders screen, the search bar at the top disappeared after opening a subfolder and navigating back, even though the folder list had scrolled back to the top. Re-selecting the Folders tab was the only way to bring it back.
- The search bar's collapsed state is saved per screen and restored on navigation, so returning from a subfolder restored the collapsed state and kept the bar hidden.
- Now, opening a subfolder saves the Folders screen as expanded, so the search bar is shown again when returning to it.

### Relies on the following changes

-

## Due diligence

- [x ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)
