### PR TITLE
feat: sleep timer fade-out

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -76,6 +76,10 @@ val RepeatModeKey = intPreferencesKey("repeatMode")
 val LockQueueKey = booleanPreferencesKey("lockQueue")
 val minPlaybackDurKey = intPreferencesKey("minPlaybackDur")
 
+val SleepTimerFadeKey = booleanPreferencesKey("sleepTimerFade")
+val SleepTimerFadeDurationKey = intPreferencesKey("sleepTimerFadeDuration")
+val SleepTimerDefaultMinutesKey = intPreferencesKey("sleepTimerDefaultMinutes")
+
 
 /**
  * Lyrics

--- a/app/src/main/java/com/dd3boh/outertune/constants/SleepTimerDefaults.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/SleepTimerDefaults.kt
@@ -1,0 +1,21 @@
+package com.dd3boh.outertune.constants
+
+/**
+ * Default values, bounds and presets for the sleep timer.
+ *
+ * Durations are stored in minutes (timer length) and seconds (fade length).
+ */
+object SleepTimerDefaults {
+    const val FADE_ENABLED = true
+
+    /** Fade length in seconds. */
+    const val FADE_DURATION_SECONDS = 30
+    val FADE_DURATION_RANGE = 5..60
+
+    /** Timer length in minutes. */
+    const val DEFAULT_MINUTES = 60
+    val MINUTES_RANGE = 1..120
+
+    /** Fixed-minute preset buttons shown in the timer dialog. */
+    val PRESET_MINUTES = listOf(15, 30, 45, 60, 75, 90)
+}

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -66,16 +66,16 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionToken
 import com.dd3boh.outertune.MainActivity
 import com.dd3boh.outertune.R
-import com.dd3boh.outertune.constants.SERVICE_DEBUG
 import com.dd3boh.outertune.constants.AudioDecoderKey
-import com.dd3boh.outertune.constants.DEFAULT_AUDIO_DECODER
 import com.dd3boh.outertune.constants.AudioGaplessOffloadKey
 import com.dd3boh.outertune.constants.AudioNormalizationKey
 import com.dd3boh.outertune.constants.AudioOffloadKey
 import com.dd3boh.outertune.constants.AudioQuality
 import com.dd3boh.outertune.constants.AudioQualityKey
 import com.dd3boh.outertune.constants.AutoLoadMoreKey
+import com.dd3boh.outertune.constants.DEFAULT_AUDIO_DECODER
 import com.dd3boh.outertune.constants.ENABLE_FFMETADATAEX
+import com.dd3boh.outertune.constants.IgnoreAudioFocusKey
 import com.dd3boh.outertune.constants.KeepAliveKey
 import com.dd3boh.outertune.constants.MAX_PLAYER_CONSECUTIVE_ERR
 import com.dd3boh.outertune.constants.MaxQueuesKey
@@ -88,7 +88,7 @@ import com.dd3boh.outertune.constants.PauseRemoteListenHistoryKey
 import com.dd3boh.outertune.constants.PersistentQueueKey
 import com.dd3boh.outertune.constants.PlayerVolumeKey
 import com.dd3boh.outertune.constants.RepeatModeKey
-import com.dd3boh.outertune.constants.IgnoreAudioFocusKey
+import com.dd3boh.outertune.constants.SERVICE_DEBUG
 import com.dd3boh.outertune.constants.SkipOnErrorKey
 import com.dd3boh.outertune.constants.SkipSilenceKey
 import com.dd3boh.outertune.constants.StopMusicOnTaskClearKey
@@ -249,6 +249,7 @@ class MusicService : MediaLibraryService(),
                 // listeners
                 addListener(this@MusicService)
                 sleepTimer = SleepTimer(scope, this)
+                sleepTimer.onCountdownFinish = { this@MusicService.pauseAllPlayersAndStopSelf() }
                 addListener(sleepTimer)
                 addAnalyticsListener(PlaybackStatsListener(false, this@MusicService))
 

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -1107,6 +1107,12 @@ class MusicService : MediaLibraryService(),
         }
     }
 
+    fun startSleepTimer(minute: Int, fadeEnabled: Boolean, fadeDurationSeconds: Int) {
+        sleepTimer.fadeEnabled = fadeEnabled
+        sleepTimer.fadeDurationMs = fadeDurationSeconds * 1000L
+        sleepTimer.start(minute)
+    }
+
     override fun onDestroy() {
         if (SERVICE_DEBUG) Log.i(TAG, "Terminating MusicService.")
         deInitQueue()

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -308,8 +308,8 @@ class MusicService : MediaLibraryService(),
                 initQueue()
             }
 
-            combine(playerVolume, normalizeFactor) { playerVolume, normalizeFactor ->
-                playerVolume * normalizeFactor
+            combine(playerVolume, normalizeFactor, sleepTimer.fadeFactor) { playerVolume, normalizeFactor, fadeFactor ->
+                playerVolume * normalizeFactor * fadeFactor
             }.collectLatest(scope) {
                 withContext(Dispatchers.Main) {
                     player.volume = it

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -249,7 +249,7 @@ class MusicService : MediaLibraryService(),
                 // listeners
                 addListener(this@MusicService)
                 sleepTimer = SleepTimer(scope, this)
-                sleepTimer.onCountdownFinish = { this@MusicService.pauseAllPlayersAndStopSelf() }
+                sleepTimer.onFinish = { this@MusicService.pauseAllPlayersAndStopSelf() }
                 addListener(sleepTimer)
                 addAnalyticsListener(PlaybackStatsListener(false, this@MusicService))
 

--- a/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
@@ -30,17 +30,32 @@ class SleepTimer(
     private val _fadeFactor = MutableStateFlow(1f)
     val fadeFactor: StateFlow<Float> = _fadeFactor.asStateFlow()
 
+    /** Action taken when the minute-based countdown reaches zero. Defaults to pausing playback. */
+    var onCountdownFinish: () -> Unit = { player.pause() }
+
     fun start(minute: Int) {
         sleepTimerJob?.cancel()
         sleepTimerJob = null
+        _fadeFactor.value = 1f
+        pauseWhenSongEnd = false
+        triggerTime = -1L
         if (minute == -1) {
             pauseWhenSongEnd = true
         } else {
-            triggerTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
+            val endTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
+            triggerTime = endTime
             sleepTimerJob = scope.launch {
-                delay(minute.minutes)
-                player.pause()
+                val untilFade = endTime - FADE_DURATION_MS - System.currentTimeMillis()
+                if (untilFade > 0) delay(untilFade)
+                while (true) {
+                    val remaining = endTime - System.currentTimeMillis()
+                    if (remaining <= 0) break
+                    _fadeFactor.value = fadeFactorFor(remaining)
+                    delay(FADE_TICK_MS)
+                }
+                onCountdownFinish()
                 triggerTime = -1L
+                _fadeFactor.value = 1f
             }
         }
     }
@@ -50,6 +65,13 @@ class SleepTimer(
         sleepTimerJob = null
         pauseWhenSongEnd = false
         triggerTime = -1L
+        _fadeFactor.value = 1f
+    }
+
+    /** Volume multiplier that fades linearly to zero over the final [FADE_DURATION_MS]. */
+    private fun fadeFactorFor(remainingMs: Long): Float {
+        if (remainingMs >= FADE_DURATION_MS) return 1f
+        return remainingMs.toFloat() / FADE_DURATION_MS
     }
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -64,5 +86,10 @@ class SleepTimer(
             pauseWhenSongEnd = false
             player.pause()
         }
+    }
+
+    companion object {
+        private const val FADE_DURATION_MS = 30_000L
+        private const val FADE_TICK_MS = 50L
     }
 }

--- a/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
@@ -9,6 +9,9 @@ import androidx.media3.common.Player
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.minutes
 
@@ -23,6 +26,9 @@ class SleepTimer(
         private set
     val isActive: Boolean
         get() = triggerTime != -1L || pauseWhenSongEnd
+
+    private val _fadeFactor = MutableStateFlow(1f)
+    val fadeFactor: StateFlow<Float> = _fadeFactor.asStateFlow()
 
     fun start(minute: Int) {
         sleepTimerJob?.cancel()

--- a/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import kotlinx.coroutines.CoroutineScope
@@ -30,8 +31,8 @@ class SleepTimer(
     private val _fadeFactor = MutableStateFlow(1f)
     val fadeFactor: StateFlow<Float> = _fadeFactor.asStateFlow()
 
-    /** Action taken when the minute-based countdown reaches zero. Defaults to pausing playback. */
-    var onCountdownFinish: () -> Unit = { player.pause() }
+    /** Called when the active sleep timer completes. */
+    var onFinish: () -> Unit = { player.pause() }
 
     fun start(minute: Int) {
         sleepTimerJob?.cancel()
@@ -41,6 +42,25 @@ class SleepTimer(
         triggerTime = -1L
         if (minute == -1) {
             pauseWhenSongEnd = true
+            sleepTimerJob = scope.launch {
+                // This job only updates fade volume. Timer completion is handled by
+                // player callbacks when playback ends or the current media item changes.
+                while (true) {
+                    val duration = player.duration
+                    val remaining = if (duration == C.TIME_UNSET || duration <= 0L) {
+                        Long.MAX_VALUE
+                    } else {
+                        duration - player.currentPosition
+                    }
+                    if (remaining <= FADE_DURATION_MS) {
+                        _fadeFactor.value = fadeFactorFor(remaining)
+                        delay(FADE_TICK_MS)
+                    } else {
+                        _fadeFactor.value = 1f
+                        delay(FADE_POLL_MS)
+                    }
+                }
+            }
         } else {
             val endTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
             triggerTime = endTime
@@ -53,7 +73,7 @@ class SleepTimer(
                     _fadeFactor.value = fadeFactorFor(remaining)
                     delay(FADE_TICK_MS)
                 }
-                onCountdownFinish()
+                onFinish()
                 triggerTime = -1L
                 _fadeFactor.value = 1f
             }
@@ -68,28 +88,31 @@ class SleepTimer(
         _fadeFactor.value = 1f
     }
 
-    /** Volume multiplier that fades linearly to zero over the final [FADE_DURATION_MS]. */
     private fun fadeFactorFor(remainingMs: Long): Float {
         if (remainingMs >= FADE_DURATION_MS) return 1f
-        return remainingMs.toFloat() / FADE_DURATION_MS
+        return (remainingMs.toFloat() / FADE_DURATION_MS).coerceIn(0f, 1f)
     }
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-        if (pauseWhenSongEnd) {
-            pauseWhenSongEnd = false
-            player.pause()
-        }
+        if (pauseWhenSongEnd) finishSongEnd()
     }
 
     override fun onPlaybackStateChanged(@Player.State playbackState: Int) {
-        if (playbackState == Player.STATE_ENDED && pauseWhenSongEnd) {
-            pauseWhenSongEnd = false
-            player.pause()
-        }
+        if (playbackState == Player.STATE_ENDED && pauseWhenSongEnd) finishSongEnd()
+    }
+
+    /** Completes stop-after-this-song mode. */
+    private fun finishSongEnd() {
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        pauseWhenSongEnd = false
+        onFinish()
+        _fadeFactor.value = 1f
     }
 
     companion object {
         private const val FADE_DURATION_MS = 30_000L
         private const val FADE_TICK_MS = 50L
+        private const val FADE_POLL_MS = 1_000L
     }
 }

--- a/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import com.dd3boh.outertune.constants.SleepTimerDefaults
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -28,6 +29,12 @@ class SleepTimer(
     val isActive: Boolean
         get() = triggerTime != -1L || pauseWhenSongEnd
 
+    /** Whether the volume fades out before the timer stops playback. */
+    var fadeEnabled: Boolean = true
+
+    /** Length of the fade-out, in milliseconds. */
+    var fadeDurationMs: Long = SleepTimerDefaults.FADE_DURATION_SECONDS * 1000L
+
     private val _fadeFactor = MutableStateFlow(1f)
     val fadeFactor: StateFlow<Float> = _fadeFactor.asStateFlow()
 
@@ -42,22 +49,24 @@ class SleepTimer(
         triggerTime = -1L
         if (minute == -1) {
             pauseWhenSongEnd = true
-            sleepTimerJob = scope.launch {
-                // This job only updates fade volume. Timer completion is handled by
-                // player callbacks when playback ends or the current media item changes.
-                while (true) {
-                    val duration = player.duration
-                    val remaining = if (duration == C.TIME_UNSET || duration <= 0L) {
-                        Long.MAX_VALUE
-                    } else {
-                        duration - player.currentPosition
-                    }
-                    if (remaining <= FADE_DURATION_MS) {
-                        _fadeFactor.value = fadeFactorFor(remaining)
-                        delay(FADE_TICK_MS)
-                    } else {
-                        _fadeFactor.value = 1f
-                        delay(FADE_POLL_MS)
+            if (fadeEnabled) {
+                sleepTimerJob = scope.launch {
+                    // This job only updates fade volume. Timer completion is handled by
+                    // player callbacks when playback ends or the current media item changes.
+                    while (true) {
+                        val duration = player.duration
+                        val remaining = if (duration == C.TIME_UNSET || duration <= 0L) {
+                            Long.MAX_VALUE
+                        } else {
+                            duration - player.currentPosition
+                        }
+                        if (remaining <= fadeDurationMs) {
+                            _fadeFactor.value = fadeFactorFor(remaining)
+                            delay(FADE_TICK_MS)
+                        } else {
+                            _fadeFactor.value = 1f
+                            delay(FADE_POLL_MS)
+                        }
                     }
                 }
             }
@@ -65,13 +74,18 @@ class SleepTimer(
             val endTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
             triggerTime = endTime
             sleepTimerJob = scope.launch {
-                val untilFade = endTime - FADE_DURATION_MS - System.currentTimeMillis()
-                if (untilFade > 0) delay(untilFade)
-                while (true) {
-                    val remaining = endTime - System.currentTimeMillis()
-                    if (remaining <= 0) break
-                    _fadeFactor.value = fadeFactorFor(remaining)
-                    delay(FADE_TICK_MS)
+                if (fadeEnabled) {
+                    val untilFade = endTime - fadeDurationMs - System.currentTimeMillis()
+                    if (untilFade > 0) delay(untilFade)
+                    while (true) {
+                        val remaining = endTime - System.currentTimeMillis()
+                        if (remaining <= 0) break
+                        _fadeFactor.value = fadeFactorFor(remaining)
+                        delay(FADE_TICK_MS)
+                    }
+                } else {
+                    val untilEnd = endTime - System.currentTimeMillis()
+                    if (untilEnd > 0) delay(untilEnd)
                 }
                 onFinish()
                 triggerTime = -1L
@@ -89,8 +103,8 @@ class SleepTimer(
     }
 
     private fun fadeFactorFor(remainingMs: Long): Float {
-        if (remainingMs >= FADE_DURATION_MS) return 1f
-        return (remainingMs.toFloat() / FADE_DURATION_MS).coerceIn(0f, 1f)
+        if (remainingMs >= fadeDurationMs) return 1f
+        return (remainingMs.toFloat() / fadeDurationMs).coerceIn(0f, 1f)
     }
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -111,7 +125,6 @@ class SleepTimer(
     }
 
     companion object {
-        private const val FADE_DURATION_MS = 30_000L
         private const val FADE_TICK_MS = 50L
         private const val FADE_POLL_MS = 1_000L
     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/dialog/Dialog.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/dialog/Dialog.kt
@@ -411,21 +411,6 @@ fun CounterDialog(
                 ) {
                     IconButton(
                         onClick = {
-                            if (tempValue.intValue < upperBound) {
-                                tempValue.intValue += 1
-                            }
-                        },
-                    ) {
-                        Text(
-                            text = "+",
-//                            fontWeight = FontWeight.Bold,
-                            style = MaterialTheme.typography.titleLarge
-                        )
-                    }
-
-
-                    IconButton(
-                        onClick = {
                             if (tempValue.intValue > lowerBound) {
                                 tempValue.intValue -= 1
                             }
@@ -434,6 +419,21 @@ fun CounterDialog(
                         Text(
                             text = "—",
                             fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleLarge
+                        )
+                    }
+
+
+                    IconButton(
+                        onClick = {
+                            if (tempValue.intValue < upperBound) {
+                                tempValue.intValue += 1
+                            }
+                        },
+                    ) {
+                        Text(
+                            text = "+",
+//                            fontWeight = FontWeight.Bold,
                             style = MaterialTheme.typography.titleLarge
                         )
                     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
@@ -20,13 +20,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.AddCircleOutline
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Equalizer
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.LibraryAdd
@@ -87,6 +87,10 @@ import com.dd3boh.outertune.LocalDownloadUtil
 import com.dd3boh.outertune.LocalPlayerConnection
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.ShowLyricsKey
+import com.dd3boh.outertune.constants.SleepTimerDefaultMinutesKey
+import com.dd3boh.outertune.constants.SleepTimerDefaults
+import com.dd3boh.outertune.constants.SleepTimerFadeDurationKey
+import com.dd3boh.outertune.constants.SleepTimerFadeKey
 import com.dd3boh.outertune.models.MediaMetadata
 import com.dd3boh.outertune.playback.ExoDownloadService
 import com.dd3boh.outertune.playback.queues.YouTubeQueue
@@ -105,8 +109,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
@@ -196,8 +198,15 @@ fun PlayerMenu(
         mutableStateOf(false)
     }
 
+    val defaultSleepMinutes by rememberPreference(SleepTimerDefaultMinutesKey, defaultValue = SleepTimerDefaults.DEFAULT_MINUTES)
+    val sleepTimerFade by rememberPreference(SleepTimerFadeKey, defaultValue = SleepTimerDefaults.FADE_ENABLED)
+    val sleepTimerFadeDuration by rememberPreference(
+        SleepTimerFadeDurationKey,
+        defaultValue = SleepTimerDefaults.FADE_DURATION_SECONDS
+    )
+
     var sleepTimerValue by remember {
-        mutableFloatStateOf(30f)
+        mutableFloatStateOf(defaultSleepMinutes.toFloat())
     }
 
     if (showSleepTimerDialog) {
@@ -213,7 +222,12 @@ fun PlayerMenu(
                 TextButton(
                     onClick = {
                         showSleepTimerDialog = false
-                        playerConnection.service.sleepTimer.start(sleepTimerValue.roundToInt())
+                        playerConnection.service.startSleepTimer(
+                            sleepTimerValue.roundToInt()
+                                .coerceIn(SleepTimerDefaults.MINUTES_RANGE.first, SleepTimerDefaults.MINUTES_RANGE.last),
+                            sleepTimerFade,
+                            sleepTimerFadeDuration
+                        )
                     }
                 ) {
                     Text(stringResource(android.R.string.ok))
@@ -227,146 +241,22 @@ fun PlayerMenu(
                 }
             },
             text = {
-                val focusRequester = remember {
-                    FocusRequester()
-                }
-
-                var showDialog by remember {
-                    mutableStateOf(false)
-                }
-
-                LaunchedEffect(showDialog) {
-                    if (showDialog) {
-                        delay(300)
-                        focusRequester.requestFocus()
-                    }
-                }
-
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    val pluralString = pluralStringResource(
-                        R.plurals.minute,
-                        sleepTimerValue.roundToInt(),
-                        sleepTimerValue.roundToInt()
+                    SleepTimerDurationPicker(
+                        minutes = sleepTimerValue,
+                        onMinutesChange = { sleepTimerValue = it },
+                        showEndTime = true,
                     )
 
-                    val endTime = System.currentTimeMillis() + (sleepTimerValue.roundToInt() * 60 * 1000).toLong()
-                    val calendarNow = Calendar.getInstance()
-                    val calendarEnd = Calendar.getInstance().apply { timeInMillis = endTime }
-
-                    // show date if it will span to next day
-                    val endTimeString =
-                        if (calendarNow.get(Calendar.DAY_OF_YEAR) == calendarEnd.get(Calendar.DAY_OF_YEAR) &&
-                            calendarNow.get(Calendar.YEAR) == calendarEnd.get(Calendar.YEAR)
+                    Box(modifier = Modifier.padding(top = 8.dp)) {
+                        OutlinedButton(
+                            onClick = {
+                                showSleepTimerDialog = false
+                                playerConnection.service.startSleepTimer(-1, sleepTimerFade, sleepTimerFadeDuration)
+                            },
+                            modifier = Modifier.height(40.dp)
                         ) {
-                            SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT, Locale.getDefault())
-                                .format(Date(endTime))
-                        } else {
-                            SimpleDateFormat.getDateTimeInstance(
-                                SimpleDateFormat.SHORT,
-                                SimpleDateFormat.SHORT,
-                                Locale.getDefault()
-                            ).format(Date(endTime))
-                        }
-
-                    Text(
-                        text = "$pluralString\n$endTimeString",
-                        style = MaterialTheme.typography.bodyLarge,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier
-                            .padding(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 8.dp)
-                            .clip(shape = RoundedCornerShape(8.dp))
-                            .clickable {
-                                showDialog = true
-                            }
-                    )
-
-                    // manual input
-                    if (showDialog) {
-                        val initialText = TextFieldValue(
-                            text = sleepTimerValue.roundToInt().toString(),
-                            selection = TextRange(0, sleepTimerValue.roundToInt().toString().length),
-                        )
-
-                        val (textFieldValue, onTextFieldValueChange) = remember {
-                            mutableStateOf(initialText)
-                        }
-
-                        TextField(
-                            value = textFieldValue,
-                            onValueChange = onTextFieldValueChange,
-                            placeholder = { Text(pluralString) },
-                            singleLine = true,
-                            leadingIcon = { Icon(Icons.Rounded.MoreTime, null) },
-                            colors = OutlinedTextFieldDefaults.colors(),
-                            keyboardOptions = KeyboardOptions(
-                                imeAction = ImeAction.Done,
-                                keyboardType = KeyboardType.Number
-                            ),
-                            keyboardActions = KeyboardActions(
-                                onDone = {
-                                    val text = textFieldValue.text.toFloatOrNull()
-                                    if (text != null) {
-                                        sleepTimerValue = textFieldValue.text.toFloatOrNull() ?: sleepTimerValue
-                                    }
-                                }
-                            ),
-                            modifier = Modifier
-                                .focusRequester(focusRequester)
-                        )
-                    }
-
-                    Slider(
-                        value = sleepTimerValue,
-                        onValueChange = { sleepTimerValue = it },
-                        valueRange = 1f..120f,
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    )
-
-                    FlowRow(
-                        horizontalArrangement = Arrangement.Center,
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        // Preset time options
-                        val timeIntervals = listOf(15L, 30L, 45L, 60L)
-
-                        // Create time chips for all intervals
-                        val timeChips = timeIntervals.map { interval ->
-                            val (timeString, duration) = getNextInterval(interval)
-                            TimeChip(
-                                duration = duration,
-                                composable = {
-                                    OutlinedButton(
-                                        onClick = { sleepTimerValue = duration },
-                                        modifier = Modifier.height(40.dp)
-                                    ) {
-                                        Text(timeString)
-                                    }
-                                }
-                            )
-                        }.sortedBy { it.duration } + remember {
-                            TimeChip(
-                                duration = Float.MAX_VALUE,
-                                composable = {
-                                    OutlinedButton(
-                                        onClick = {
-                                            showSleepTimerDialog = false
-                                            playerConnection.service.sleepTimer.start(-1)
-                                        },
-                                        modifier = Modifier.height(40.dp)
-                                    ) {
-                                        Text(stringResource(R.string.end_of_song))
-                                    }
-                                }
-                            )
-                        }
-
-                        timeChips.forEach { timeChip ->
-                            Box(
-                                modifier = Modifier
-                                    .padding(horizontal = 4.dp)
-                            ) {
-                                timeChip.composable()
-                            }
+                            Text(stringResource(R.string.end_of_song))
                         }
                     }
                 }
@@ -528,8 +418,12 @@ fun PlayerMenu(
             sleepTimerTimeLeft = sleepTimerTimeLeft,
             enabled = sleepTimerEnabled
         ) {
-            if (sleepTimerEnabled) playerConnection.service.sleepTimer.clear()
-            else showSleepTimerDialog = true
+            if (sleepTimerEnabled) {
+                playerConnection.service.sleepTimer.clear()
+            } else {
+                sleepTimerValue = defaultSleepMinutes.toFloat()
+                showSleepTimerDialog = true
+            }
         }
         GridMenuItem(
             icon = Icons.Rounded.Equalizer,
@@ -728,39 +622,162 @@ fun <T> ValueAdjuster(
     }
 }
 
-data class TimeChip(
-    val duration: Float,
-    val composable: @Composable () -> Unit
-) : Comparable<TimeChip> {
-    override fun compareTo(other: TimeChip): Int {
-        return duration.compareTo(other.duration)
+@Composable
+fun SleepTimerDurationPicker(
+    minutes: Float,
+    onMinutesChange: (Float) -> Unit,
+    showEndTime: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    var showInput by remember { mutableStateOf(false) }
+
+    LaunchedEffect(showInput) {
+        if (showInput) {
+            delay(300)
+            focusRequester.requestFocus()
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+    ) {
+        val minutesInt = minutes.roundToInt()
+        val pluralString = pluralStringResource(R.plurals.minute, minutesInt, minutesInt)
+
+        val displayText = if (showEndTime) {
+            val endTime = System.currentTimeMillis() + (minutesInt * 60 * 1000).toLong()
+            val calendarNow = Calendar.getInstance()
+            val calendarEnd = Calendar.getInstance().apply { timeInMillis = endTime }
+            // show date if it will span to next day
+            val endTimeString =
+                if (calendarNow.get(Calendar.DAY_OF_YEAR) == calendarEnd.get(Calendar.DAY_OF_YEAR) &&
+                    calendarNow.get(Calendar.YEAR) == calendarEnd.get(Calendar.YEAR)
+                ) {
+                    SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT, Locale.getDefault())
+                        .format(Date(endTime))
+                } else {
+                    SimpleDateFormat.getDateTimeInstance(
+                        SimpleDateFormat.SHORT,
+                        SimpleDateFormat.SHORT,
+                        Locale.getDefault()
+                    ).format(Date(endTime))
+                }
+            "$pluralString\n$endTimeString"
+        } else {
+            pluralString
+        }
+
+        Text(
+            text = displayText,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .padding(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 8.dp)
+                .clip(shape = RoundedCornerShape(8.dp))
+                .clickable { showInput = true }
+        )
+
+        // manual input
+        if (showInput) {
+            val initialText = TextFieldValue(
+                text = minutesInt.toString(),
+                selection = TextRange(0, minutesInt.toString().length),
+            )
+
+            val (textFieldValue, onTextFieldValueChange) = remember {
+                mutableStateOf(initialText)
+            }
+
+            TextField(
+                value = textFieldValue,
+                onValueChange = {
+                    onTextFieldValueChange(it)
+                    it.text.toFloatOrNull()?.let { value ->
+                        onMinutesChange(
+                            value.coerceIn(
+                                SleepTimerDefaults.MINUTES_RANGE.first.toFloat(),
+                                SleepTimerDefaults.MINUTES_RANGE.last.toFloat()
+                            )
+                        )
+                    }
+                },
+                placeholder = { Text(pluralString) },
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Rounded.MoreTime, null) },
+                colors = OutlinedTextFieldDefaults.colors(),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Done,
+                    keyboardType = KeyboardType.Number
+                ),
+                modifier = Modifier.focusRequester(focusRequester)
+            )
+        }
+
+        Slider(
+            value = minutes,
+            onValueChange = onMinutesChange,
+            valueRange = SleepTimerDefaults.MINUTES_RANGE.first.toFloat()..SleepTimerDefaults.MINUTES_RANGE.last.toFloat(),
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        FlowRow(
+            horizontalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            SleepTimerDefaults.PRESET_MINUTES.forEach { preset ->
+                Box(modifier = Modifier.padding(horizontal = 4.dp)) {
+                    OutlinedButton(
+                        onClick = { onMinutesChange(preset.toFloat()) },
+                        modifier = Modifier.height(40.dp)
+                    ) {
+                        Text(stringResource(R.string.sleep_timer_minutes_short, preset))
+                    }
+                }
+            }
+        }
     }
 }
 
-fun getNextInterval(targetMin: Long): Pair<String, Float> {
-    require(targetMin in 1..60) { "Interval must be between 1 and 60 minutes" }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepTimerDefaultTimeDialog(
+    initialMinutes: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (Int) -> Unit,
+) {
+    var minutes by remember { mutableFloatStateOf(initialMinutes.toFloat()) }
 
-    val now = LocalDateTime.now()
-    val intervalMinutes = targetMin - now.minute
-
-    val targetTime: LocalDateTime = if (intervalMinutes > 0) {
-        // Within this hour
-        now.plusMinutes(intervalMinutes)
-    } else if (intervalMinutes < 0) {
-        // Next hour
-        now.plusHours(1).plusMinutes(targetMin - now.minute)
-//        now.plusMinutes((60 - now.minute) + targetMin)        // other way to calculate targetTime
-    } else {
-        // Equal to 0
-        now.plusHours(1)
-    }
-
-    // Format the time
-    val timeString = SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT, Locale.getDefault())
-        .format(Date(targetTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()))
-
-    // Calculate minutes between now and target
-    val minutesBetween = ChronoUnit.MINUTES.between(now, targetTime).toFloat()
-
-    return Pair(timeString, minutesBetween)
+    AlertDialog(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        onDismissRequest = onDismiss,
+        icon = { Icon(imageVector = Icons.Rounded.Bedtime, contentDescription = null) },
+        title = { Text(stringResource(R.string.sleep_timer_default_time)) },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(
+                    minutes.roundToInt()
+                        .coerceIn(SleepTimerDefaults.MINUTES_RANGE.first, SleepTimerDefaults.MINUTES_RANGE.last)
+                )
+            }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        text = {
+            SleepTimerDurationPicker(
+                minutes = minutes,
+                onMinutesChange = { minutes = it },
+                showEndTime = false,
+            )
+        }
+    )
 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
@@ -52,6 +52,7 @@ import com.dd3boh.outertune.ui.screens.settings.fragments.AudioEffectsFrag
 import com.dd3boh.outertune.ui.screens.settings.fragments.AudioQualityFrag
 import com.dd3boh.outertune.ui.screens.settings.fragments.PlaybackBehaviourFrag
 import com.dd3boh.outertune.ui.screens.settings.fragments.PlayerGeneralFrag
+import com.dd3boh.outertune.ui.screens.settings.fragments.SleepTimerFrag
 import com.dd3boh.outertune.ui.utils.backToMain
 import com.dd3boh.outertune.utils.rememberPreference
 import androidx.compose.foundation.layout.WindowInsets
@@ -119,6 +120,16 @@ fun PlayerSettings(
             modifier = Modifier.fillMaxWidth()
         ) {
             PlaybackBehaviourFrag()
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PreferenceGroupTitle(
+            title = stringResource(R.string.sleep_timer)
+        )
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            SleepTimerFrag()
         }
 
         SettingsClickToReveal(stringResource(R.string.advanced)) {

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/PlayerFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/PlayerFrag.kt
@@ -1,14 +1,17 @@
 package com.dd3boh.outertune.ui.screens.settings.fragments
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.VolumeDown
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.Autorenew
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.ClearAll
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.Headset
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Timelapse
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.AudioNormalizationKey
@@ -30,12 +34,17 @@ import com.dd3boh.outertune.constants.SeekIncrement
 import com.dd3boh.outertune.constants.SeekIncrementKey
 import com.dd3boh.outertune.constants.SkipOnErrorKey
 import com.dd3boh.outertune.constants.SkipSilenceKey
+import com.dd3boh.outertune.constants.SleepTimerDefaultMinutesKey
+import com.dd3boh.outertune.constants.SleepTimerDefaults
+import com.dd3boh.outertune.constants.SleepTimerFadeDurationKey
+import com.dd3boh.outertune.constants.SleepTimerFadeKey
 import com.dd3boh.outertune.constants.StopMusicOnTaskClearKey
 import com.dd3boh.outertune.constants.minPlaybackDurKey
 import com.dd3boh.outertune.ui.component.EnumListPreference
 import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.SwitchPreference
 import com.dd3boh.outertune.ui.dialog.CounterDialog
+import com.dd3boh.outertune.ui.menu.SleepTimerDefaultTimeDialog
 import com.dd3boh.outertune.utils.rememberEnumPreference
 import com.dd3boh.outertune.utils.rememberPreference
 import androidx.compose.ui.tooling.preview.Preview
@@ -184,6 +193,75 @@ fun PlaybackBehaviourFrag() {
             },
             onCancel = {
                 showMinPlaybackDur = false
+            }
+        )
+    }
+}
+
+@Composable
+fun SleepTimerFrag() {
+    val (fade, onFadeChange) = rememberPreference(SleepTimerFadeKey, defaultValue = SleepTimerDefaults.FADE_ENABLED)
+    val (fadeDuration, onFadeDurationChange) = rememberPreference(
+        SleepTimerFadeDurationKey,
+        defaultValue = SleepTimerDefaults.FADE_DURATION_SECONDS
+    )
+    val (defaultMinutes, onDefaultMinutesChange) = rememberPreference(
+        SleepTimerDefaultMinutesKey,
+        defaultValue = SleepTimerDefaults.DEFAULT_MINUTES
+    )
+
+    var showFadeDurationDialog by remember { mutableStateOf(false) }
+    var showDefaultTimeDialog by remember { mutableStateOf(false) }
+
+    SwitchPreference(
+        title = { Text(stringResource(R.string.sleep_timer_fade)) },
+        icon = { Icon(Icons.AutoMirrored.Rounded.VolumeDown, null) },
+        checked = fade,
+        onCheckedChange = onFadeChange
+    )
+    PreferenceEntry(
+        title = { Text(stringResource(R.string.sleep_timer_fade_duration)) },
+        description = stringResource(R.string.sleep_timer_fade_duration_desc),
+        icon = { Icon(Icons.Rounded.Timelapse, null) },
+        isEnabled = fade,
+        onClick = { showFadeDurationDialog = true }
+    )
+    PreferenceEntry(
+        title = { Text(stringResource(R.string.sleep_timer_default_time)) },
+        description = pluralStringResource(R.plurals.minute, defaultMinutes, defaultMinutes),
+        icon = { Icon(Icons.Rounded.Bedtime, null) },
+        onClick = { showDefaultTimeDialog = true }
+    )
+
+    /**
+     * ---------------------------
+     * Dialogs
+     * ---------------------------
+     */
+
+    if (showFadeDurationDialog) {
+        CounterDialog(
+            title = stringResource(R.string.sleep_timer_fade_duration),
+            description = stringResource(R.string.sleep_timer_fade_duration_desc),
+            initialValue = fadeDuration,
+            upperBound = SleepTimerDefaults.FADE_DURATION_RANGE.last,
+            lowerBound = SleepTimerDefaults.FADE_DURATION_RANGE.first,
+            unitDisplay = " " + stringResource(R.string.sleep_timer_second_unit),
+            onDismiss = { showFadeDurationDialog = false },
+            onConfirm = {
+                showFadeDurationDialog = false
+                onFadeDurationChange(it)
+            },
+            onCancel = { showFadeDurationDialog = false }
+        )
+    }
+    if (showDefaultTimeDialog) {
+        SleepTimerDefaultTimeDialog(
+            initialMinutes = defaultMinutes,
+            onDismiss = { showDefaultTimeDialog = false },
+            onConfirm = {
+                showDefaultTimeDialog = false
+                onDefaultMinutesChange(it)
             }
         )
     }

--- a/app/src/main/res/values-ja/strings-ot.xml
+++ b/app/src/main/res/values-ja/strings-ot.xml
@@ -99,6 +99,12 @@
     <string name="keep_alive_description">OuterTuneがバックグラウンドで終了されないよう、永続的なフォアグラウンドサービスを使用します</string>
     <string name="min_playback_duration">最小の再生時間</string>
     <string name="min_playback_duration_description">曲を「再生済み」と判断するための、最低限の再生時間</string>
+    <string name="sleep_timer_fade">フェードアウト</string>
+    <string name="sleep_timer_fade_duration">フェード時間</string>
+    <string name="sleep_timer_fade_duration_desc">停止前に音量を下げ始める秒数</string>
+    <string name="sleep_timer_default_time">デフォルトスリープ時間</string>
+    <string name="sleep_timer_minutes_short">%d 分</string>
+    <string name="sleep_timer_second_unit">秒</string>
     <string name="scanner_progress_syncing">同期中…</string>
     <string name="scanner_scan_fail">スキャンが失敗しました</string>
     <string name="scanner_ytm_link_fail">YouTube アーティストのリンク ジョブが失敗しました</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -168,6 +168,12 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="persistent_queue_desc_ot">Restore previous open queue(s) when the app starts</string>
     <string name="min_playback_duration">Minimum playback duration</string>
     <string name="min_playback_duration_description">The minimum amount of a song that must be played before it is considered \"played\"</string>
+    <string name="sleep_timer_fade">Fade out</string>
+    <string name="sleep_timer_fade_duration">Fade duration</string>
+    <string name="sleep_timer_fade_duration_desc">Seconds to lower the volume before stopping</string>
+    <string name="sleep_timer_default_time">Default sleep time</string>
+    <string name="sleep_timer_minutes_short">%d min</string>
+    <string name="sleep_timer_second_unit">s</string>
     <string name="swipe2Queue">Swipe to queue</string>
     <string name="swipe2Queue_description">Swipe on a song to add it to "enqueue next" directly after currently playing song</string>
     <string name="seek_increment">Seek increment</string>


### PR DESCRIPTION
## What is it?

- [x] New feature (user facing)
- [x] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Adds fade-out support to the sleep timer for both timed timers and "end of song" mode.
- Fully stops playback when the sleep timer finishes, instead of only pausing playback, so the service and notification are cleared.
- Applies the sleep timer fade as a separate volume factor on top of the user volume and audio normalization.
- Adds sleep timer settings under Player and audio:
  - Fade out on/off
  - Fade duration, defaulting to 30 seconds with a 5-60 second range
  - Default sleep time, defaulting to 60 minutes
- Updates the sleep timer dialog to open with the configured default sleep time.
- Replaces clock-boundary preset buttons with fixed-minute presets: 15, 30, 45, 60, 75, and 90 minutes.
- Reuses the same duration picker for the sleep timer dialog and the default sleep time setting.
- Fixes the CounterDialog minus/plus button order.

### Before/After Screenshots/Screen Record

- Before: The sleep timer stopped playback when the selected time was reached.
- After: The sleep timer can lower the volume before playback stops.
<img width="274" height="640" alt="Screenshot_20260705-163326" src="https://github.com/user-attachments/assets/0b8b80e7-57a4-4468-bae4-cd58e46c3ec2" />
<img width="274" height="640" alt="Screenshot_20260705-163335" src="https://github.com/user-attachments/assets/4c39ec41-e608-41e9-a60c-d4f7408ca676" />
<img width="274" height="640" alt="Screenshot_20260705-163344" src="https://github.com/user-attachments/assets/9cb168bc-412f-4399-9f7c-65d3c5347788" />
<img width="274" height="640" alt="Screenshot_20260705-163435" src="https://github.com/user-attachments/assets/468fcbca-f31e-4e85-a981-7b3591e97f1c" />

### Fixes the following issue(s)

- Related issue: OuterTune/OuterTune#1251 (the remaining-time notification is out of scope here)

### Relies on the following changes

-

## Due diligence

- [ ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)