### PR TITLE
feat: add a sleep timer button to the player screen

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -79,6 +79,7 @@ val minPlaybackDurKey = intPreferencesKey("minPlaybackDur")
 val SleepTimerFadeKey = booleanPreferencesKey("sleepTimerFade")
 val SleepTimerFadeDurationKey = intPreferencesKey("sleepTimerFadeDuration")
 val SleepTimerDefaultMinutesKey = intPreferencesKey("sleepTimerDefaultMinutes")
+val SleepTimerShowOnPlayerKey = booleanPreferencesKey("sleepTimerShowOnPlayer")
 
 
 /**

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
@@ -198,70 +198,8 @@ fun PlayerMenu(
         mutableStateOf(false)
     }
 
-    val defaultSleepMinutes by rememberPreference(SleepTimerDefaultMinutesKey, defaultValue = SleepTimerDefaults.DEFAULT_MINUTES)
-    val sleepTimerFade by rememberPreference(SleepTimerFadeKey, defaultValue = SleepTimerDefaults.FADE_ENABLED)
-    val sleepTimerFadeDuration by rememberPreference(
-        SleepTimerFadeDurationKey,
-        defaultValue = SleepTimerDefaults.FADE_DURATION_SECONDS
-    )
-
-    var sleepTimerValue by remember {
-        mutableFloatStateOf(defaultSleepMinutes.toFloat())
-    }
-
     if (showSleepTimerDialog) {
-        AlertDialog(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            properties = DialogProperties(usePlatformDefaultWidth = false),
-            onDismissRequest = { showSleepTimerDialog = false },
-            icon = { Icon(imageVector = Icons.Rounded.Timer, contentDescription = null) },
-            title = { Text(stringResource(R.string.sleep_timer)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showSleepTimerDialog = false
-                        playerConnection.service.startSleepTimer(
-                            sleepTimerValue.roundToInt()
-                                .coerceIn(SleepTimerDefaults.MINUTES_RANGE.first, SleepTimerDefaults.MINUTES_RANGE.last),
-                            sleepTimerFade,
-                            sleepTimerFadeDuration
-                        )
-                    }
-                ) {
-                    Text(stringResource(android.R.string.ok))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showSleepTimerDialog = false }
-                ) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-            },
-            text = {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    SleepTimerDurationPicker(
-                        minutes = sleepTimerValue,
-                        onMinutesChange = { sleepTimerValue = it },
-                        showEndTime = true,
-                    )
-
-                    Box(modifier = Modifier.padding(top = 8.dp)) {
-                        OutlinedButton(
-                            onClick = {
-                                showSleepTimerDialog = false
-                                playerConnection.service.startSleepTimer(-1, sleepTimerFade, sleepTimerFadeDuration)
-                            },
-                            modifier = Modifier.height(40.dp)
-                        ) {
-                            Text(stringResource(R.string.end_of_song))
-                        }
-                    }
-                }
-            }
-        )
+        SleepTimerDialog(onDismiss = { showSleepTimerDialog = false })
     }
 
     var showDetailsDialog by rememberSaveable {
@@ -418,12 +356,7 @@ fun PlayerMenu(
             sleepTimerTimeLeft = sleepTimerTimeLeft,
             enabled = sleepTimerEnabled
         ) {
-            if (sleepTimerEnabled) {
-                playerConnection.service.sleepTimer.clear()
-            } else {
-                sleepTimerValue = defaultSleepMinutes.toFloat()
-                showSleepTimerDialog = true
-            }
+            showSleepTimerDialog = true
         }
         GridMenuItem(
             icon = Icons.Rounded.Equalizer,
@@ -503,6 +436,98 @@ fun PlayerMenu(
         )
     }
 
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepTimerDialog(
+    onDismiss: () -> Unit,
+) {
+    val playerConnection = LocalPlayerConnection.current ?: return
+
+    val defaultSleepMinutes by rememberPreference(
+        SleepTimerDefaultMinutesKey,
+        defaultValue = SleepTimerDefaults.DEFAULT_MINUTES
+    )
+    val sleepTimerFade by rememberPreference(SleepTimerFadeKey, defaultValue = SleepTimerDefaults.FADE_ENABLED)
+    val sleepTimerFadeDuration by rememberPreference(
+        SleepTimerFadeDurationKey,
+        defaultValue = SleepTimerDefaults.FADE_DURATION_SECONDS
+    )
+
+    val sleepTimerActive = remember(
+        playerConnection.service.sleepTimer.triggerTime,
+        playerConnection.service.sleepTimer.pauseWhenSongEnd
+    ) {
+        playerConnection.service.sleepTimer.isActive
+    }
+
+    var sleepTimerValue by remember {
+        mutableFloatStateOf(defaultSleepMinutes.toFloat())
+    }
+
+    AlertDialog(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        onDismissRequest = onDismiss,
+        icon = { Icon(imageVector = Icons.Rounded.Timer, contentDescription = null) },
+        title = { Text(stringResource(R.string.sleep_timer)) },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDismiss()
+                    playerConnection.service.startSleepTimer(
+                        sleepTimerValue.roundToInt()
+                            .coerceIn(SleepTimerDefaults.MINUTES_RANGE.first, SleepTimerDefaults.MINUTES_RANGE.last),
+                        sleepTimerFade,
+                        sleepTimerFadeDuration
+                    )
+                }
+            ) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (sleepTimerActive) {
+                    TextButton(
+                        onClick = {
+                            onDismiss()
+                            playerConnection.service.sleepTimer.clear()
+                        }
+                    ) {
+                        Text(stringResource(R.string.sleep_timer_stop))
+                    }
+                }
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        },
+        text = {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                SleepTimerDurationPicker(
+                    minutes = sleepTimerValue,
+                    onMinutesChange = { sleepTimerValue = it },
+                    showEndTime = true,
+                )
+
+                Box(modifier = Modifier.padding(top = 8.dp)) {
+                    OutlinedButton(
+                        onClick = {
+                            onDismiss()
+                            playerConnection.service.startSleepTimer(-1, sleepTimerFade, sleepTimerFadeDuration)
+                        },
+                        modifier = Modifier.height(40.dp)
+                    ) {
+                        Text(stringResource(R.string.end_of_song))
+                    }
+                }
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -56,6 +56,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Lyrics as LyricsOutlined
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
@@ -132,6 +133,7 @@ import com.dd3boh.outertune.constants.SeekIncrement
 import com.dd3boh.outertune.constants.SeekIncrementKey
 import com.dd3boh.outertune.constants.SliderStyleKey
 import com.dd3boh.outertune.constants.ShowLyricsKey
+import com.dd3boh.outertune.constants.SleepTimerShowOnPlayerKey
 import com.dd3boh.outertune.constants.SwipeToSkipKey
 import com.dd3boh.outertune.extensions.isPowerSaver
 import com.dd3boh.outertune.extensions.metadata
@@ -150,6 +152,7 @@ import com.dd3boh.outertune.ui.component.collapsedAnchor
 import com.dd3boh.outertune.ui.component.dismissedAnchor
 import com.dd3boh.outertune.ui.component.rememberBottomSheetState
 import com.dd3boh.outertune.ui.menu.PlayerMenu
+import com.dd3boh.outertune.ui.menu.SleepTimerDialog
 import com.dd3boh.outertune.ui.theme.extractGradientColors
 import com.dd3boh.outertune.ui.utils.SnapLayoutInfoProvider
 import com.dd3boh.outertune.utils.coilCoroutine
@@ -566,7 +569,82 @@ fun ActionButtons(
 
     var showLyrics by rememberPreference(ShowLyricsKey, defaultValue = false)
 
+    val showSleepTimerButton by rememberPreference(SleepTimerShowOnPlayerKey, defaultValue = true)
+
+    val sleepTimerActive = remember(
+        playerConnection.service.sleepTimer.triggerTime,
+        playerConnection.service.sleepTimer.pauseWhenSongEnd
+    ) {
+        playerConnection.service.sleepTimer.isActive
+    }
+
+    var sleepTimerTimeLeft by remember {
+        mutableLongStateOf(0L)
+    }
+
+    LaunchedEffect(sleepTimerActive) {
+        if (sleepTimerActive) {
+            while (isActive) {
+                sleepTimerTimeLeft = if (playerConnection.service.sleepTimer.pauseWhenSongEnd) {
+                    playerConnection.player.duration - playerConnection.player.currentPosition
+                } else {
+                    playerConnection.service.sleepTimer.triggerTime - System.currentTimeMillis()
+                }
+                delay(1000L)
+            }
+        }
+    }
+
+    var showSleepTimerDialog by remember {
+        mutableStateOf(false)
+    }
+
+    if (showSleepTimerDialog) {
+        SleepTimerDialog(onDismiss = { showSleepTimerDialog = false })
+    }
+
     Spacer(modifier = Modifier.width(10.dp))
+
+    if (showSleepTimerButton) {
+        if (sleepTimerActive) {
+            Box(
+                modifier = Modifier
+                    .offset(y = 5.dp)
+                    .height(36.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(MaterialTheme.colorScheme.primary)
+                    .clickable { showSleepTimerDialog = true }
+                    .padding(horizontal = 12.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = makeTimeString(sleepTimerTimeLeft),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .offset(y = 5.dp)
+                    .size(36.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(MaterialTheme.colorScheme.primary)
+            ) {
+                ResizableIconButton(
+                    icon = Icons.Rounded.Bedtime,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(24.dp),
+                    onClick = { showSleepTimerDialog = true }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(7.dp))
+    }
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/PlayerFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/PlayerFrag.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.rounded.Headset
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material.icons.rounded.Timelapse
+import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +39,7 @@ import com.dd3boh.outertune.constants.SleepTimerDefaultMinutesKey
 import com.dd3boh.outertune.constants.SleepTimerDefaults
 import com.dd3boh.outertune.constants.SleepTimerFadeDurationKey
 import com.dd3boh.outertune.constants.SleepTimerFadeKey
+import com.dd3boh.outertune.constants.SleepTimerShowOnPlayerKey
 import com.dd3boh.outertune.constants.StopMusicOnTaskClearKey
 import com.dd3boh.outertune.constants.minPlaybackDurKey
 import com.dd3boh.outertune.ui.component.EnumListPreference
@@ -209,10 +211,18 @@ fun SleepTimerFrag() {
         SleepTimerDefaultMinutesKey,
         defaultValue = SleepTimerDefaults.DEFAULT_MINUTES
     )
+    val (showOnPlayer, onShowOnPlayerChange) = rememberPreference(SleepTimerShowOnPlayerKey, defaultValue = true)
 
     var showFadeDurationDialog by remember { mutableStateOf(false) }
     var showDefaultTimeDialog by remember { mutableStateOf(false) }
 
+    SwitchPreference(
+        title = { Text(stringResource(R.string.sleep_timer_show_on_player)) },
+        description = stringResource(R.string.sleep_timer_show_on_player_desc),
+        icon = { Icon(Icons.Rounded.Visibility, null) },
+        checked = showOnPlayer,
+        onCheckedChange = onShowOnPlayerChange
+    )
     SwitchPreference(
         title = { Text(stringResource(R.string.sleep_timer_fade)) },
         icon = { Icon(Icons.AutoMirrored.Rounded.VolumeDown, null) },

--- a/app/src/main/res/values-ja/strings-ot.xml
+++ b/app/src/main/res/values-ja/strings-ot.xml
@@ -105,6 +105,9 @@
     <string name="sleep_timer_default_time">デフォルトスリープ時間</string>
     <string name="sleep_timer_minutes_short">%d 分</string>
     <string name="sleep_timer_second_unit">秒</string>
+    <string name="sleep_timer_stop">タイマー停止</string>
+    <string name="sleep_timer_show_on_player">プレーヤー画面に表示</string>
+    <string name="sleep_timer_show_on_player_desc">プレーヤー画面にスリープタイマーボタンを表示する</string>
     <string name="scanner_progress_syncing">同期中…</string>
     <string name="scanner_scan_fail">スキャンが失敗しました</string>
     <string name="scanner_ytm_link_fail">YouTube アーティストのリンク ジョブが失敗しました</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -174,6 +174,9 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="sleep_timer_default_time">Default sleep time</string>
     <string name="sleep_timer_minutes_short">%d min</string>
     <string name="sleep_timer_second_unit">s</string>
+    <string name="sleep_timer_stop">Stop timer</string>
+    <string name="sleep_timer_show_on_player">Player screen button</string>
+    <string name="sleep_timer_show_on_player_desc">Show a sleep timer button on the player screen</string>
     <string name="swipe2Queue">Swipe to queue</string>
     <string name="swipe2Queue_description">Swipe on a song to add it to "enqueue next" directly after currently playing song</string>
     <string name="seek_increment">Seek increment</string>


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Add a sleep timer button to the player screen, left of the lyrics button. It shows the Bedtime icon when idle and the remaining time as a pill when the timer is running.
- Tapping the button in either state opens the timer dialog. While the timer is running, the dialog has a "Stop timer" button that cancels it.
- The player menu's sleep timer item now opens the same dialog when tapped while active, instead of clearing the timer immediately. Its remaining-time label is unchanged.
- Add a setting to show or hide the button (enabled by default), placed above the fade-out option under Player and audio › Sleep timer.

### Before/After Screenshots/Screen Record

- Before:

<img width="274" height="640" alt="outertune" src="https://github.com/user-attachments/assets/c4e2dbfd-8b33-4d10-8c6d-4c6bc8e8c07c" />

- After:
- 
<img width="270" height="600" alt="Screenshot_20260706_122451" src="https://github.com/user-attachments/assets/1d5b0f00-5c7e-452b-9b2a-6182d7f5151b" />

### Fixes the following issue(s)

- Fixes #53

### Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed