### PR TITLE
feat: add Wi-Fi only download toggle

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -101,6 +101,7 @@ val LyricUpdateSpeed = stringPreferencesKey("lyricUpdateSpeed")
  */
 val DownloadExtraPathKey = stringPreferencesKey("dlExtraPath") // previously "downloadExtraPath"
 val DownloadPathKey = stringPreferencesKey("dlPath") // previously "downloadPath"
+val DownloadOnWifiOnlyKey = booleanPreferencesKey("downloadOnWifiOnly")
 val MaxImageCacheSizeKey = intPreferencesKey("maxImageCacheSize")
 val MaxSongCacheSizeKey = intPreferencesKey("maxSongCacheSize")
 

--- a/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
@@ -18,10 +18,13 @@ import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
+import androidx.media3.exoplayer.scheduler.Requirements
+import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.AudioQuality
 import com.dd3boh.outertune.constants.AudioQualityKey
 import com.dd3boh.outertune.constants.DOWNLOAD_DEBUG
 import com.dd3boh.outertune.constants.DownloadExtraPathKey
+import com.dd3boh.outertune.constants.DownloadOnWifiOnlyKey
 import com.dd3boh.outertune.constants.DownloadPathKey
 import com.dd3boh.outertune.db.MusicDatabase
 import com.dd3boh.outertune.db.entities.FormatEntity
@@ -140,6 +143,7 @@ class DownloadUtil @Inject constructor(
     val downloadManager: DownloadManager =
         DownloadManager(context, databaseProvider, downloadCache, dataSourceFactory, Executor(Runnable::run)).apply {
             maxParallelDownloads = 3
+            requirements = downloadRequirements(context.dataStore.get(DownloadOnWifiOnlyKey, true))
             addListener(
                 ExoDownloadService.TerminalStateNotificationHelper(
                     context = context,
@@ -161,15 +165,41 @@ class DownloadUtil @Inject constructor(
     fun getDownload(songId: String): Flow<LocalDateTime?> = downloads.map { it[songId] }
 
     fun download(songs: List<MediaMetadata>) {
+        if (songs.any { downloads.value[it.id] == null }) notifyIfWaitingForWifi()
         songs.forEach { song -> downloadSong(song.id, song.title) }
     }
 
     fun download(song: MediaMetadata) {
+        if (downloads.value[song.id] == null) notifyIfWaitingForWifi()
         downloadSong(song.id, song.title)
     }
 
     fun download(song: SongEntity) {
+        if (downloads.value[song.id] == null) notifyIfWaitingForWifi()
         downloadSong(song.id, song.title)
+    }
+
+    /**
+     * Update the network requirement for downloads. Takes effect immediately, including for
+     * downloads that are already queued or in progress.
+     */
+    fun setDownloadRequirements(wifiOnly: Boolean) {
+        DownloadService.sendSetRequirements(
+            context,
+            ExoDownloadService::class.java,
+            downloadRequirements(wifiOnly),
+            false
+        )
+    }
+
+    /**
+     * Show a hint when a download is requested on a metered network while Wi-Fi only is enabled,
+     * since the download is queued silently and only starts once Wi-Fi is available.
+     */
+    private fun notifyIfWaitingForWifi() {
+        if (context.dataStore.get(DownloadOnWifiOnlyKey, true) && connectivityManager.isActiveNetworkMetered) {
+            Toast.makeText(context, R.string.download_waiting_for_wifi, LENGTH_SHORT).show()
+        }
     }
 
     private fun downloadSong(id: String, title: String) {
@@ -425,6 +455,9 @@ class DownloadUtil @Inject constructor(
     companion object {
         val STATE_DOWNLOADING: LocalDateTime = Instant.ofEpochMilli(1).atZone(ZoneOffset.UTC).toLocalDateTime()
         val STATE_INVALID: LocalDateTime = Instant.ofEpochMilli(0).atZone(ZoneOffset.UTC).toLocalDateTime()
+
+        fun downloadRequirements(wifiOnly: Boolean): Requirements =
+            Requirements(if (wifiOnly) Requirements.NETWORK_UNMETERED else Requirements.NETWORK)
     }
 
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/StorageFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/StorageFrag.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.rounded.Downloading
 import androidx.compose.material.icons.rounded.FolderCopy
 import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -59,6 +60,7 @@ import com.dd3boh.outertune.LocalDownloadUtil
 import com.dd3boh.outertune.LocalPlayerConnection
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.DownloadExtraPathKey
+import com.dd3boh.outertune.constants.DownloadOnWifiOnlyKey
 import com.dd3boh.outertune.constants.DownloadPathKey
 import com.dd3boh.outertune.constants.MaxImageCacheSizeKey
 import com.dd3boh.outertune.constants.MaxSongCacheSizeKey
@@ -69,6 +71,7 @@ import com.dd3boh.outertune.extensions.tryOrNull
 import com.dd3boh.outertune.ui.component.ListPreference
 import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.SettingsClickToReveal
+import com.dd3boh.outertune.ui.component.SwitchPreference
 import com.dd3boh.outertune.ui.component.button.IconButton
 import com.dd3boh.outertune.ui.component.button.ResizableIconButton
 import com.dd3boh.outertune.ui.dialog.ActionPromptDialog
@@ -145,6 +148,7 @@ fun ColumnScope.DownloadsFrag() {
 
     val (downloadPath, onDownloadPathChange) = rememberPreference(DownloadPathKey, "")
     val (scanPaths, onScanPathsChange) = rememberPreference(ScanPathsKey, defaultValue = "")
+    val (downloadOnWifiOnly, onDownloadOnWifiOnlyChange) = rememberPreference(DownloadOnWifiOnlyKey, defaultValue = true)
 
     // size stats
     var downloadCacheSize by remember {
@@ -187,6 +191,17 @@ fun ColumnScope.DownloadsFrag() {
             downloadCacheSize = tryOrNull { downloadCache.cacheSpace } ?: 0
         }
     }
+
+    SwitchPreference(
+        title = { Text(stringResource(R.string.download_on_wifi_only_title)) },
+        description = stringResource(R.string.download_on_wifi_only_description),
+        icon = { Icon(Icons.Rounded.Wifi, null) },
+        checked = downloadOnWifiOnly,
+        onCheckedChange = {
+            onDownloadOnWifiOnlyChange(it)
+            downloadUtil.setDownloadRequirements(it)
+        }
+    )
 
     PreferenceEntry(
         title = { Text(stringResource(R.string.dl_main_path_title)) },

--- a/app/src/main/res/values-ja/strings-ot.xml
+++ b/app/src/main/res/values-ja/strings-ot.xml
@@ -198,6 +198,9 @@
     <string name="oobe_downloads_subtitle">ダウンロードした曲を保存するフォルダを選択します。</string>
     <string name="oobe_complete_title">準備完了です！</string>
     <string name="scan_paths_description">曲をスキャンしたい端末内の保存領域のフォルダを選択</string>
+    <string name="download_on_wifi_only_title">Wi-Fi接続時のみダウンロード</string>
+    <string name="download_on_wifi_only_description">モバイルデータ通信ではダウンロードしません。モバイルデータ通信中に追加した曲は、Wi-Fi接続後に自動でダウンロードを開始します</string>
+    <string name="download_waiting_for_wifi">Wi-Fi接続後にダウンロードします</string>
     <string name="clear_downloads_confirm">すべてのダウンロードメディアを削除しますか？メインのダウンロードフォルダ内のダウンロードのみが削除されます。</string>
     <string name="clear_image_cache_confirm">画像のキャッシュを削除しますか？ 既存のアルバムのサムネイルはすべて削除されます。</string>
     <string name="dl_extra_path_title">追加のインポート場所を設定…</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -265,6 +265,9 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="scanner_online_artist_linking">Try to link local files\' artists with ones on YouTube Music</string>
 
 <!-- Storage setting -->
+    <string name="download_on_wifi_only_title">Download only on Wi-Fi</string>
+    <string name="download_on_wifi_only_description">Don\'t download over mobile data. Songs queued while on mobile data start downloading automatically once Wi-Fi is available</string>
+    <string name="download_waiting_for_wifi">Will download once connected to Wi-Fi</string>
     <string name="clear_downloads_confirm">Are you sure you want to remove all downloads? Only downloads in the main download folder will be removed.</string>
     <string name="clear_image_cache_confirm">Are you sure you want to clear image cache? All exiting album thumbnails will be removed.</string>
     <string name="clear_song_cache_confirm">Are you sure you want to clear song cache?</string>


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Add a "Download only on Wi-Fi" setting (enabled by default) under Settings > Storage > Downloaded songs.
- When enabled, downloads run only on unmetered networks. Downloads requested on mobile data are queued and start automatically once Wi-Fi is available.
- An in-progress download pauses when the connection switches from Wi-Fi to mobile data and resumes when Wi-Fi returns.
- A toast notifies the user when a download is queued while on mobile data.
- Toggling the setting takes effect immediately for queued and in-progress downloads.
- Applies to all download actions (single song, album, playlist, and multi-select).

### Before/After Screenshots/Screen Record

- After:
<img width="270" height="600" alt="Screenshot_20260706_175946" src="https://github.com/user-attachments/assets/49c8379f-86f1-4a3c-878c-9bab2b4d92c1" />


### Fixes the following issue(s)

- Fixes #48

### Relies on the following changes

-

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)
