### PR TITLE
feat: replace the tab search bar with a top icon row

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -19,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -32,11 +30,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.TrendingUp
 import androidx.compose.material.icons.rounded.Casino
-import androidx.compose.material.icons.rounded.History
-import androidx.compose.material.icons.rounded.Person
-import androidx.compose.material.icons.rounded.SdCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
@@ -69,7 +63,6 @@ import com.dd3boh.outertune.constants.GridThumbnailHeight
 import com.dd3boh.outertune.constants.InnerTubeCookieKey
 import com.dd3boh.outertune.constants.ListItemHeight
 import com.dd3boh.outertune.constants.ListThumbnailSize
-import com.dd3boh.outertune.constants.LocalLibraryEnableKey
 import com.dd3boh.outertune.constants.ThumbnailCornerRadius
 import com.dd3boh.outertune.db.entities.Album
 import com.dd3boh.outertune.db.entities.Artist
@@ -85,7 +78,6 @@ import com.dd3boh.outertune.playback.queues.YouTubeQueue
 import com.dd3boh.outertune.ui.component.ChipsRow
 import com.dd3boh.outertune.ui.component.HideOnScrollFAB
 import com.dd3boh.outertune.ui.component.LazyColumnScrollbar
-import com.dd3boh.outertune.ui.component.NavigationTile
 import com.dd3boh.outertune.ui.component.NavigationTitle
 import com.dd3boh.outertune.ui.component.ScrollToTopManager
 import com.dd3boh.outertune.ui.component.items.AlbumGridItem
@@ -161,7 +153,6 @@ fun HomeScreen(
     val forgottenFavoritesLazyGridState = rememberLazyGridState()
     val recentActivityGridState = rememberLazyGridState()
 
-    val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
     val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
     val isLoggedIn = remember(innerTubeCookie) {
         "SAPISID" in parseCookieString(innerTubeCookie)
@@ -391,50 +382,6 @@ fun HomeScreen(
             state = lazylistState,
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
         ) {
-            item {
-                Row(
-                    modifier = Modifier
-                        .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
-                        .padding(horizontal = 12.dp, vertical = 6.dp)
-                        .fillMaxWidth()
-                        .animateItem()
-                ) {
-                    NavigationTile(
-                        title = stringResource(R.string.history),
-                        icon = Icons.Rounded.History,
-                        onClick = { navController.navigate("history") },
-                        modifier = Modifier.weight(1f)
-                    )
-
-                    NavigationTile(
-                        title = stringResource(R.string.stats),
-                        icon = Icons.AutoMirrored.Rounded.TrendingUp,
-                        onClick = { navController.navigate("stats") },
-                        modifier = Modifier.weight(1f)
-                    )
-
-                    if (localLibEnable) {
-                        NavigationTile(
-                            title = stringResource(R.string.scanner_local_title),
-                            icon = Icons.Rounded.SdCard,
-                            onClick = {
-                                navController.navigate("settings/local")
-                            },
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-
-                    NavigationTile(
-                        title = stringResource(R.string.account),
-                        icon = Icons.Rounded.Person,
-                        onClick = {
-                            navController.navigate("account")
-                        },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-            }
-
             item {
                 ChipsRow(
                     chips = homePage?.chips?.mapNotNull { it to it.title } ?: emptyList(),

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -6,22 +6,35 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.TrendingUp
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Language
 import androidx.compose.material.icons.rounded.LibraryMusic
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.SdCard
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,6 +44,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,9 +56,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAny
 import androidx.core.net.toUri
@@ -54,15 +72,20 @@ import com.dd3boh.outertune.LocalDatabase
 import com.dd3boh.outertune.LocalPlayerAwareWindowInsets
 import com.dd3boh.outertune.LocalPlayerConnection
 import com.dd3boh.outertune.R
+import com.dd3boh.outertune.constants.AppBarHeight
 import com.dd3boh.outertune.constants.DEFAULT_ENABLED_TABS
 import com.dd3boh.outertune.constants.EnabledTabsKey
+import com.dd3boh.outertune.constants.LocalLibraryEnableKey
 import com.dd3boh.outertune.constants.PauseSearchHistoryKey
 import com.dd3boh.outertune.constants.SearchSource
 import com.dd3boh.outertune.constants.SearchSourceKey
 import com.dd3boh.outertune.constants.UpdateAvailableKey
 import com.dd3boh.outertune.db.entities.SearchHistory
 import com.dd3boh.outertune.extensions.tabMode
+import com.dd3boh.outertune.ui.component.InputFieldHeight
 import com.dd3boh.outertune.ui.component.SearchBar
+import com.dd3boh.outertune.ui.component.SearchBarHorizontalPadding
+import com.dd3boh.outertune.ui.component.SearchBarVerticalPadding
 import com.dd3boh.outertune.ui.component.button.IconButton
 import com.dd3boh.outertune.ui.screens.Screens
 import com.dd3boh.outertune.utils.dataStore
@@ -71,6 +94,8 @@ import com.dd3boh.outertune.utils.rememberEnumPreference
 import com.dd3boh.outertune.utils.rememberPreference
 import com.dd3boh.outertune.utils.urlEncode
 import com.dd3boh.outertune.youtubeNavigator
+import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -83,11 +108,13 @@ fun SearchBarContainer(
     val coroutineScope = rememberCoroutineScope()
     val database = LocalDatabase.current
     val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val playerConnection = LocalPlayerConnection.current
 
     val enabledTabs by rememberPreference(EnabledTabsKey, defaultValue = DEFAULT_ENABLED_TABS)
     var searchSource by rememberEnumPreference(SearchSourceKey, SearchSource.ONLINE)
     val updateAvailable by rememberPreference(UpdateAvailableKey, defaultValue = false)
+    val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
 
     val navigationItems = remember { Screens.getScreens(enabledTabs) }
     val searchBarFocusRequester = remember { FocusRequester() }
@@ -141,9 +168,17 @@ fun SearchBarContainer(
     }
 
 
-    val shouldShowSearchBar = remember(searchActive, navBackStackEntry) {
-        (searchActive || navigationItems.fastAny { it.route == navBackStackEntry?.destination?.route } ||
-                navBackStackEntry?.destination?.route?.startsWith("search/") == true)
+    val isTabRoute = navigationItems.fastAny { it.route == navBackStackEntry?.destination?.route }
+    val isSearchRoute = navBackStackEntry?.destination?.route?.startsWith("search/") == true
+    val showSearchBar = searchActive || isSearchRoute
+    val showIconRow = isTabRoute && !searchActive && !isSearchRoute
+
+    LaunchedEffect(searchActive) {
+        if (searchActive) {
+            delay(100)
+            searchBarFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
     }
 
     val savedHeightOffsets = remember { mutableMapOf<String, Float>() }
@@ -165,7 +200,7 @@ fun SearchBarContainer(
     }
 
     AnimatedVisibility(
-        visible = shouldShowSearchBar,
+        visible = showSearchBar,
         enter = fadeIn(),
         exit = fadeOut()
     ) {
@@ -309,6 +344,109 @@ fun SearchBarContainer(
                     )
                 }
             }
+        }
+    }
+
+    AnimatedVisibility(
+        visible = showIconRow,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        val iconRowInset = if (!context.tabMode()) {
+            WindowInsets.safeDrawing.union(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Start))
+        } else {
+            WindowInsets()
+        }
+        TopIconBar(
+            scrollBehavior = scrollBehavior,
+            windowInsets = iconRowInset,
+            localLibEnable = localLibEnable,
+            onHistoryClick = { navController.navigate("history") },
+            onStatsClick = { navController.navigate("stats") },
+            onScannerClick = { navController.navigate("settings/local") },
+            onSettingsClick = { navController.navigate("settings") },
+            onAccountClick = { navController.navigate("account") },
+            onSearchClick = { onSearchActiveChange(true) },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TopIconBar(
+    scrollBehavior: TopAppBarScrollBehavior,
+    windowInsets: WindowInsets,
+    localLibEnable: Boolean,
+    onHistoryClick: () -> Unit,
+    onStatsClick: () -> Unit,
+    onScannerClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    onAccountClick: () -> Unit,
+    onSearchClick: () -> Unit,
+) {
+    val heightOffsetLimit = with(LocalDensity.current) {
+        -(AppBarHeight.toPx() + WindowInsets.systemBars.getTop(this))
+    }
+    SideEffect {
+        if (scrollBehavior.state.heightOffsetLimit != heightOffsetLimit) {
+            scrollBehavior.state.heightOffsetLimit = heightOffsetLimit
+        }
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .offset {
+                IntOffset(x = 0, y = scrollBehavior.state.heightOffset.roundToInt())
+            }
+            .fillMaxWidth()
+            .windowInsetsPadding(windowInsets)
+            .padding(horizontal = SearchBarHorizontalPadding, vertical = SearchBarVerticalPadding)
+            .height(InputFieldHeight)
+    ) {
+        Image(
+            painter = painterResource(R.drawable.app_logo),
+            contentDescription = null,
+            modifier = Modifier.size(36.dp)
+        )
+        Spacer(Modifier.weight(1f))
+        IconButton(onClick = onSearchClick) {
+            Icon(
+                imageVector = Icons.Rounded.Search,
+                contentDescription = stringResource(R.string.search)
+            )
+        }
+        IconButton(onClick = onHistoryClick) {
+            Icon(
+                imageVector = Icons.Rounded.History,
+                contentDescription = stringResource(R.string.history)
+            )
+        }
+        IconButton(onClick = onStatsClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.TrendingUp,
+                contentDescription = stringResource(R.string.stats)
+            )
+        }
+        if (localLibEnable) {
+            IconButton(onClick = onScannerClick) {
+                Icon(
+                    imageVector = Icons.Rounded.SdCard,
+                    contentDescription = stringResource(R.string.scanner_local_title)
+                )
+            }
+        }
+        IconButton(onClick = onSettingsClick) {
+            Icon(
+                imageVector = Icons.Rounded.Settings,
+                contentDescription = stringResource(R.string.settings)
+            )
+        }
+        IconButton(onClick = onAccountClick) {
+            Icon(
+                imageVector = Icons.Rounded.Person,
+                contentDescription = stringResource(R.string.account)
+            )
         }
     }
 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -208,7 +208,7 @@ fun SearchBarContainer(
             WindowInsets.safeDrawing.union(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Start))
         }
         else {
-            WindowInsets()
+            WindowInsets.systemBars.only(WindowInsetsSides.Top)
         }
         SearchBar(
             query = query,
@@ -355,7 +355,7 @@ fun SearchBarContainer(
         val iconRowInset = if (!context.tabMode()) {
             WindowInsets.safeDrawing.union(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Start))
         } else {
-            WindowInsets()
+            WindowInsets.systemBars.only(WindowInsetsSides.Top)
         }
         TopIconBar(
             scrollBehavior = scrollBehavior,

--- a/app/src/main/res/drawable/app_logo.xml
+++ b/app/src/main/res/drawable/app_logo.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="48dp" android:viewportHeight="96" android:viewportWidth="96" android:width="48dp">
+
+    <group android:translateX="-51" android:translateY="-43">
+
+        <path android:fillAlpha="0.4" android:fillColor="#c04450" android:pathData="M76.37,53.25C68.78,48.91 62.63,52.47 62.63,61.19v64.35c0,8.73 6.15,12.28 13.75,7.94l56.43,-32.25c7.59,-4.34 7.59,-11.38 0,-15.72z" android:strokeWidth="0.351516"/>
+
+        <path android:fillColor="#ed5564" android:pathData="m74.21,49.26c-7.59,-4.34 -13.75,-0.78 -13.75,7.93v64.35c0,8.73 6.15,12.28 13.75,7.94L130.64,97.23c7.59,-4.34 7.59,-11.38 0,-15.72z" android:strokeWidth="0.351517"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m114.74,86.35l0,6.04a1.51,2.08 90,0 0,4.15 0L118.89,86.35a1.51,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.21"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="M106.9,77.54L106.9,101.2a1.97,2.08 90,0 0,4.15 0L111.05,77.54a1.97,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.39"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m99.06,84.77l0,9.2a2.3,2.08 90,0 0,4.15 0L103.21,84.77a2.3,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.5"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m91.22,78.39l0,21.96a1.83,2.08 90,0 0,4.15 0L95.37,78.39a1.83,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.34"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m83.38,71.45l0,35.84a1.79,2.08 90,0 0,4.15 0L87.53,71.45a1.79,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.32"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m75.54,79.57l0,19.6a1.63,2.08 90,0 0,4.15 0L79.69,79.57a1.63,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.26"/>
+
+        <path android:fillAlpha="0.9" android:fillColor="#ffffff" android:pathData="m67.7,85.82l0,7.1a1.77,2.08 90,0 0,4.15 0L71.85,85.82a1.77,2.08 90,0 0,-4.15 0z" android:strokeWidth="1.31"/>
+
+    </group>
+
+</vector>


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [x] Bugfix (user facing)

### Description of the changes in your PR

- Replace the collapsed search bar on tab screens with a right-aligned icon row: OuterTune logo, search, history, stats, local scanner, settings, and account.
- Open the full-screen search with the keyboard focused when the search icon is tapped.
- Remove the navigation tile row from the home screen.
- On tablet, position the top icon row and the search bar just below the status bar so they align with the content and no longer leave empty space or overlap the status bar.

### After Screenshots

<img width="270" height="600" alt="Screenshot_20260707_130816" src="https://github.com/user-attachments/assets/f4f613cf-ea8b-4a96-a09a-dcb0403442a1" />
<img width="640" height="400" alt="Screenshot_20260707_130716" src="https://github.com/user-attachments/assets/dc1bd57f-a183-4680-8ce3-c4e76d76a88c" />



### Fixes the following issue(s)

- Fixes #

### Relies on the following changes

-

## Due diligence

- [ ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).
