### PR TITLE
feat: Add a Local tab for browsing on-device music

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -159,6 +159,7 @@ import com.dd3boh.outertune.ui.screens.library.LibraryArtistsScreen
 import com.dd3boh.outertune.ui.screens.library.LibraryFoldersScreen
 import com.dd3boh.outertune.ui.screens.library.LibraryPlaylistsScreen
 import com.dd3boh.outertune.ui.screens.library.LibraryScreen
+import com.dd3boh.outertune.ui.screens.library.LocalScreen
 import com.dd3boh.outertune.ui.screens.library.LibrarySongsScreen
 import com.dd3boh.outertune.ui.screens.playlist.AutoPlaylistScreen
 import com.dd3boh.outertune.ui.screens.playlist.LocalPlaylistScreen
@@ -529,6 +530,9 @@ class MainActivity : ComponentActivity() {
                                         )
                                     ) {
                                         FolderScreen(navController, scrollBehavior)
+                                    }
+                                    composable(Screens.LocalFiles.route) {
+                                        LocalScreen(navController)
                                     }
                                     composable(Screens.Artists.route) {
                                         LibraryArtistsScreen(navController)

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -176,6 +176,11 @@ val PlaylistViewTypeKey = stringPreferencesKey("playlistViewType")
 val LibraryFilterKey = stringPreferencesKey("libraryFilter")
 val LibraryViewTypeKey = stringPreferencesKey("libraryViewType")
 
+val LocalFilterKey = stringPreferencesKey("localFilter")
+val LocalViewTypeKey = stringPreferencesKey("localViewType")
+val LocalSongSortTypeKey = stringPreferencesKey("localSongSortType")
+val LocalSongSortDescendingKey = booleanPreferencesKey("localSongSortDescending")
+
 val PlaylistEditLockKey = booleanPreferencesKey("playlistEditLock")
 
 val SearchSourceKey = stringPreferencesKey("searchSource")

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -184,6 +184,8 @@ val LocalAlbumSortTypeKey = stringPreferencesKey("localAlbumSortType")
 val LocalAlbumSortDescendingKey = booleanPreferencesKey("localAlbumSortDescending")
 val LocalArtistSortTypeKey = stringPreferencesKey("localArtistSortType")
 val LocalArtistSortDescendingKey = booleanPreferencesKey("localArtistSortDescending")
+val LocalPlaylistSortTypeKey = stringPreferencesKey("localPlaylistSortType")
+val LocalPlaylistSortDescendingKey = booleanPreferencesKey("localPlaylistSortDescending")
 
 val PlaylistEditLockKey = booleanPreferencesKey("playlistEditLock")
 

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -180,6 +180,10 @@ val LocalFilterKey = stringPreferencesKey("localFilter")
 val LocalViewTypeKey = stringPreferencesKey("localViewType")
 val LocalSongSortTypeKey = stringPreferencesKey("localSongSortType")
 val LocalSongSortDescendingKey = booleanPreferencesKey("localSongSortDescending")
+val LocalAlbumSortTypeKey = stringPreferencesKey("localAlbumSortType")
+val LocalAlbumSortDescendingKey = booleanPreferencesKey("localAlbumSortDescending")
+val LocalArtistSortTypeKey = stringPreferencesKey("localArtistSortType")
+val LocalArtistSortDescendingKey = booleanPreferencesKey("localArtistSortDescending")
 
 val PlaylistEditLockKey = booleanPreferencesKey("playlistEditLock")
 

--- a/app/src/main/java/com/dd3boh/outertune/constants/Settings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/Settings.kt
@@ -35,7 +35,7 @@ enum class LyricsPosition {
     LEFT, CENTER, RIGHT
 }
 
-const val DEFAULT_ENABLED_TABS = "HSFM"
+const val DEFAULT_ENABLED_TABS = "HSFOM"
 const val DEFAULT_ENABLED_FILTERS = "ARP"
 const val DEFAULT_SWIPE_TO_SKIP = true
 
@@ -231,6 +231,10 @@ enum class AlbumFilter {
 
 enum class PlaylistFilter {
     LIBRARY, DOWNLOADED
+}
+
+enum class LocalFilter {
+    SONGS, ALBUMS, ARTISTS, PLAYLISTS
 }
 
 enum class SearchSource {

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/AlbumsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/AlbumsDao.kt
@@ -131,6 +131,17 @@ interface AlbumsDao : ArtistsDao {
     fun artistAlbumsPreview(artistId: String, previewSize: Int = 6): Flow<List<Album>>
 
     @Transaction
+    @Query("""
+        SELECT album.*, count(song.dateDownload) downloadCount
+        FROM album_artist_map
+            JOIN album ON album_artist_map.albumId = album.id
+            JOIN song ON album_artist_map.albumId = song.albumId
+        WHERE artistId = :artistId
+        GROUP BY album.id
+    """)
+    fun artistAlbums(artistId: String): Flow<List<Album>>
+
+    @Transaction
     @RawQuery(observedEntities = [AlbumEntity::class])
     fun _getAlbum(query: SupportSQLiteQuery): Flow<List<Album>>
 

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/AlbumsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/AlbumsDao.kt
@@ -134,7 +134,7 @@ interface AlbumsDao : ArtistsDao {
     @RawQuery(observedEntities = [AlbumEntity::class])
     fun _getAlbum(query: SupportSQLiteQuery): Flow<List<Album>>
 
-    fun albums(filter: AlbumFilter, sortType: AlbumSortType, descending: Boolean): Flow<List<Album>> {
+    fun albums(filter: AlbumFilter, sortType: AlbumSortType, descending: Boolean, localOnly: Boolean? = null): Flow<List<Album>> {
         val orderBy = when (sortType) {
             AlbumSortType.CREATE_DATE -> "album.rowId ASC"
             AlbumSortType.NAME -> "album.title COLLATE NOCASE ASC"
@@ -153,6 +153,12 @@ interface AlbumsDao : ArtistsDao {
             AlbumFilter.DOWNLOADED -> "song.dateDownload IS NOT NULL"
             AlbumFilter.LIBRARY -> "song.inLibrary IS NOT NULL"
             AlbumFilter.LIKED -> "album.bookmarkedAt IS NOT NULL"
+        } + if (localOnly == null) {
+            ""
+        } else if (localOnly) {
+            " AND album.isLocal = 1"
+        } else {
+            " AND album.isLocal = 0"
         }
 
         val query = SimpleSQLiteQuery("""

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/ArtistsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/ArtistsDao.kt
@@ -144,9 +144,9 @@ interface ArtistsDao {
         } + if (localOnly == null) {
             ""
         } else if (localOnly) {
-            "artist.isLocal = 1"
+            " AND artist.isLocal = 1"
         } else {
-            "artist.isLocal = 0"
+            " AND artist.isLocal = 0"
         }
 
         val having = when (filter) {

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/ArtistsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/ArtistsDao.kt
@@ -15,6 +15,7 @@ import com.dd3boh.outertune.constants.ArtistSongSortType
 import com.dd3boh.outertune.constants.ArtistSortType
 import com.dd3boh.outertune.db.entities.Artist
 import com.dd3boh.outertune.db.entities.ArtistEntity
+import com.dd3boh.outertune.db.entities.LocalArtistThumbnail
 import com.dd3boh.outertune.db.entities.Song
 import com.dd3boh.outertune.db.entities.SongArtistMap
 import com.dd3boh.outertune.extensions.reversed
@@ -193,6 +194,24 @@ interface ArtistsDao {
         ORDER BY artist.name ASC
     """)
     fun localArtistsByName(): List<Artist>
+
+    /**
+     * Representative artwork path for each local artist, preferring a local album cover and falling
+     * back to a local song's embedded artwork. MIN() keeps the choice stable across rescans.
+     */
+    @Query("""
+        SELECT sam.artistId AS artistId,
+               COALESCE(
+                   MIN(CASE WHEN album.isLocal = 1 THEN album.thumbnailUrl END),
+                   MIN(CASE WHEN song.isLocal = 1 THEN song.thumbnailUrl END)
+               ) AS thumbnailUrl
+        FROM song_artist_map sam
+            JOIN song ON sam.songId = song.id
+            LEFT JOIN album ON song.albumId = album.id
+        WHERE song.isLocal = 1
+        GROUP BY sam.artistId
+    """)
+    fun localArtistThumbnails(): Flow<List<LocalArtistThumbnail>>
     // endregion
 
     // region Artist Songs Sort

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/PlaylistsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/PlaylistsDao.kt
@@ -106,7 +106,7 @@ interface PlaylistsDao {
      * 1 -> local playlists (WHERE p.isLocal AND p.bookmarkedAt IS NOT NULL)
      * 2 -> editable playlists (WHERE p.isEditable AND p.bookmarkedAt IS NOT NULL)
      */
-    fun playlists(filter: PlaylistFilter, sortType: PlaylistSortType, descending: Boolean, variant: Int = 0): Flow<List<Playlist>> {
+    fun playlists(filter: PlaylistFilter, sortType: PlaylistSortType, descending: Boolean, variant: Int = 0, localSongsOnly: Boolean = false): Flow<List<Playlist>> {
         val orderBy = when (sortType) {
             PlaylistSortType.CREATE_DATE -> "p.rowId ASC"
             PlaylistSortType.NAME -> "p.name COLLATE NOCASE ASC"
@@ -116,6 +116,10 @@ interface PlaylistsDao {
         val having = when (filter) {
             PlaylistFilter.DOWNLOADED -> "HAVING SUM(CASE WHEN s.dateDownload IS NOT NULL THEN 1 ELSE 0 END) > 0"
             else -> ""
+        }.let { base ->
+            if (!localSongsOnly) base
+            else if (base.isEmpty()) "HAVING SUM(CASE WHEN s.isLocal = 0 THEN 1 ELSE 0 END) = 0"
+            else "$base AND SUM(CASE WHEN s.isLocal = 0 THEN 1 ELSE 0 END) = 0"
         }
 
         val where = when (variant) {

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/SongsDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/SongsDao.kt
@@ -149,6 +149,10 @@ interface SongsDao {
     fun allLocalSongs(): List<Song>
 
     @Transaction
+    @Query("SELECT * FROM song WHERE isLocal = 1 AND inLibrary IS NOT NULL")
+    fun allLocalSongsFlow(): Flow<List<Song>>
+
+    @Transaction
     @Query("SELECT * FROM song WHERE isLocal = 1")
     fun allLocalDbSongs(): List<Song>
 

--- a/app/src/main/java/com/dd3boh/outertune/db/entities/LocalArtistThumbnail.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/entities/LocalArtistThumbnail.kt
@@ -1,0 +1,9 @@
+package com.dd3boh.outertune.db.entities
+
+/**
+ * Representative artwork path for a local artist, derived from the artist's local albums or songs.
+ */
+data class LocalArtistThumbnail(
+    val artistId: String,
+    val thumbnailUrl: String?,
+)

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/items/ArtistItems.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/items/ArtistItems.kt
@@ -26,6 +26,7 @@ import coil3.compose.AsyncImage
 import com.dd3boh.outertune.constants.ListThumbnailSize
 import com.dd3boh.outertune.db.entities.Artist
 import com.dd3boh.outertune.ui.utils.getNSongsString
+import com.dd3boh.outertune.utils.getThumbnailModel
 
 @Composable
 fun ArtistListItem(
@@ -65,7 +66,7 @@ fun ArtistListItem(
     badges = badges,
     thumbnailContent = {
         AsyncImage(
-            model = artist.artist.thumbnailUrl,
+            model = artist.artist.thumbnailUrl?.let { getThumbnailModel(it) },
             contentDescription = null,
             modifier = Modifier
                 .size(ListThumbnailSize)
@@ -114,7 +115,7 @@ fun ArtistGridItem(
     badges = badges,
     thumbnailContent = {
         AsyncImage(
-            model = artist.artist.thumbnailUrl,
+            model = artist.artist.thumbnailUrl?.let { getThumbnailModel(it) },
             contentDescription = null,
             contentScale = ContentScale.Companion.Crop,
             modifier = Modifier

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/Screens.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/Screens.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.rounded.LibraryMusic
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PlayCircle
+import androidx.compose.material.icons.rounded.SdCard
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.dd3boh.outertune.R
@@ -32,6 +33,7 @@ sealed class Screens(
     data object Home : Screens(R.string.home, Icons.Rounded.Home, "home")
     data object Songs : Screens(R.string.songs, Icons.Rounded.MusicNote, "songs")
     data object Folders : Screens(R.string.folders, Icons.Rounded.Folder, "folders")
+    data object LocalFiles : Screens(R.string.local_files, Icons.Rounded.SdCard, "local_files")
     data object Artists : Screens(R.string.artists, Icons.Rounded.Person, "artists")
     data object Albums : Screens(R.string.albums, Icons.Rounded.Album, "albums")
     data object Playlists : Screens(R.string.playlists, Icons.AutoMirrored.Rounded.QueueMusic, "playlists")
@@ -51,6 +53,7 @@ sealed class Screens(
          * H: Home
          * S: Songs
          * F: Folders
+         * O: Local Files
          * A: Artists
          * B: Albums
          * L: Playlists
@@ -65,6 +68,7 @@ sealed class Screens(
             Home to 'H',
             Songs to 'S',
             Folders to 'F',
+            LocalFiles to 'O',
             Artists to 'A',
             Albums to 'B',
             Playlists to 'L',

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,17 +51,26 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.dd3boh.outertune.LocalMenuState
 import com.dd3boh.outertune.LocalPlayerAwareWindowInsets
 import com.dd3boh.outertune.LocalPlayerConnection
 import com.dd3boh.outertune.LocalSnackbarHostState
 import com.dd3boh.outertune.MainActivity
 import com.dd3boh.outertune.R
+import com.dd3boh.outertune.constants.AlbumSortType
+import com.dd3boh.outertune.constants.ArtistSortType
+import com.dd3boh.outertune.constants.CONTENT_TYPE_ALBUM
+import com.dd3boh.outertune.constants.CONTENT_TYPE_ARTIST
 import com.dd3boh.outertune.constants.CONTENT_TYPE_HEADER
 import com.dd3boh.outertune.constants.CONTENT_TYPE_SONG
 import com.dd3boh.outertune.constants.FolderSongSortType
 import com.dd3boh.outertune.constants.GridThumbnailHeight
 import com.dd3boh.outertune.constants.LibraryViewType
 import com.dd3boh.outertune.constants.ListThumbnailSize
+import com.dd3boh.outertune.constants.LocalAlbumSortDescendingKey
+import com.dd3boh.outertune.constants.LocalAlbumSortTypeKey
+import com.dd3boh.outertune.constants.LocalArtistSortDescendingKey
+import com.dd3boh.outertune.constants.LocalArtistSortTypeKey
 import com.dd3boh.outertune.constants.LocalFilter
 import com.dd3boh.outertune.constants.LocalFilterKey
 import com.dd3boh.outertune.constants.LocalLibraryEnableKey
@@ -74,6 +84,10 @@ import com.dd3boh.outertune.ui.component.ChipsRow
 import com.dd3boh.outertune.ui.component.EmptyPlaceholder
 import com.dd3boh.outertune.ui.component.LazyColumnScrollbar
 import com.dd3boh.outertune.ui.component.LazyVerticalGridScrollbar
+import com.dd3boh.outertune.ui.component.LibraryAlbumGridItem
+import com.dd3boh.outertune.ui.component.LibraryAlbumListItem
+import com.dd3boh.outertune.ui.component.LibraryArtistGridItem
+import com.dd3boh.outertune.ui.component.LibraryArtistListItem
 import com.dd3boh.outertune.ui.component.ScrollToTopManager
 import com.dd3boh.outertune.ui.component.SortHeader
 import com.dd3boh.outertune.ui.component.button.IconButton
@@ -93,17 +107,25 @@ fun LocalScreen(
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
+    val menuState = LocalMenuState.current
+    val coroutineScope = rememberCoroutineScope()
     val playerConnection = LocalPlayerConnection.current ?: return
     val snackbarHostState = LocalSnackbarHostState.current
 
     var filter by rememberEnumPreference(LocalFilterKey, LocalFilter.SONGS)
     var viewType by rememberEnumPreference(LocalViewTypeKey, LibraryViewType.GRID)
-    val (sortType, onSortTypeChange) = rememberEnumPreference(LocalSongSortTypeKey, FolderSongSortType.TRACK_NUMBER)
-    val (sortDescending, onSortDescendingChange) = rememberPreference(LocalSongSortDescendingKey, false)
+    val (songSortType, onSongSortTypeChange) = rememberEnumPreference(LocalSongSortTypeKey, FolderSongSortType.TRACK_NUMBER)
+    val (songSortDescending, onSongSortDescendingChange) = rememberPreference(LocalSongSortDescendingKey, false)
+    val (albumSortType, onAlbumSortTypeChange) = rememberEnumPreference(LocalAlbumSortTypeKey, AlbumSortType.CREATE_DATE)
+    val (albumSortDescending, onAlbumSortDescendingChange) = rememberPreference(LocalAlbumSortDescendingKey, true)
+    val (artistSortType, onArtistSortTypeChange) = rememberEnumPreference(LocalArtistSortTypeKey, ArtistSortType.CREATE_DATE)
+    val (artistSortDescending, onArtistSortDescendingChange) = rememberPreference(LocalArtistSortDescendingKey, true)
     val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
     val swipeEnabled by rememberPreference(SwipeToQueueKey, true)
 
     val songs by viewModel.localSongs.collectAsState()
+    val albums by viewModel.localAlbums.collectAsState()
+    val artists by viewModel.localArtists.collectAsState()
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
@@ -169,10 +191,10 @@ fun LocalScreen(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
             SortHeader(
-                sortType = sortType,
-                sortDescending = sortDescending,
-                onSortTypeChange = onSortTypeChange,
-                onSortDescendingChange = onSortDescendingChange,
+                sortType = songSortType,
+                sortDescending = songSortDescending,
+                onSortTypeChange = onSongSortTypeChange,
+                onSortDescendingChange = onSongSortDescendingChange,
                 sortTypeText = { sortType ->
                     when (sortType) {
                         FolderSongSortType.CREATE_DATE -> R.string.sort_by_create_date
@@ -191,6 +213,71 @@ fun LocalScreen(
             songs?.let { songs ->
                 Text(
                     text = pluralStringResource(R.plurals.n_song, songs.size, songs.size),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+
+    val albumHeaderContent = @Composable {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            SortHeader(
+                sortType = albumSortType,
+                sortDescending = albumSortDescending,
+                onSortTypeChange = onAlbumSortTypeChange,
+                onSortDescendingChange = onAlbumSortDescendingChange,
+                sortTypeText = { sortType ->
+                    when (sortType) {
+                        AlbumSortType.CREATE_DATE -> R.string.sort_by_create_date
+                        AlbumSortType.NAME -> R.string.sort_by_name
+                        AlbumSortType.ARTIST -> R.string.sort_by_artist
+                        AlbumSortType.YEAR -> R.string.sort_by_year
+                        AlbumSortType.SONG_COUNT -> R.string.sort_by_song_count
+                        AlbumSortType.LENGTH -> R.string.sort_by_length
+                    }
+                }
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            albums?.let { albums ->
+                Text(
+                    text = pluralStringResource(R.plurals.n_album, albums.size, albums.size),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+
+    val artistHeaderContent = @Composable {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            SortHeader(
+                sortType = artistSortType,
+                sortDescending = artistSortDescending,
+                onSortTypeChange = onArtistSortTypeChange,
+                onSortDescendingChange = onArtistSortDescendingChange,
+                sortTypeText = { sortType ->
+                    when (sortType) {
+                        ArtistSortType.CREATE_DATE -> R.string.sort_by_create_date
+                        ArtistSortType.NAME -> R.string.sort_by_name
+                        ArtistSortType.SONG_COUNT -> R.string.sort_by_song_count
+                    }
+                }
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            artists?.let { artists ->
+                Text(
+                    text = pluralStringResource(R.plurals.n_artist, artists.size, artists.size),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.secondary
                 )
@@ -272,7 +359,76 @@ fun LocalScreen(
                             }
                         }
 
-                        else -> {
+                        LocalFilter.ALBUMS -> {
+                            item(
+                                key = "header",
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                albumHeaderContent()
+                            }
+
+                            albums?.let { albums ->
+                                if (albums.isEmpty()) {
+                                    item {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.Album,
+                                            text = stringResource(R.string.library_album_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = albums,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_ALBUM }
+                                ) { _, album ->
+                                    LibraryAlbumListItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        album = album,
+                                        isActive = album.id == mediaMetadata?.album?.id,
+                                        isPlaying = isPlaying,
+                                        modifier = Modifier.animateItem()
+                                    )
+                                }
+                            }
+                        }
+
+                        LocalFilter.ARTISTS -> {
+                            item(
+                                key = "header",
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                artistHeaderContent()
+                            }
+
+                            artists?.let { artists ->
+                                if (artists.isEmpty()) {
+                                    item {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.Person,
+                                            text = stringResource(R.string.library_artist_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = artists,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_ARTIST }
+                                ) { _, artist ->
+                                    LibraryArtistListItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        coroutineScope = coroutineScope,
+                                        modifier = Modifier.animateItem(),
+                                        artist = artist
+                                    )
+                                }
+                            }
+                        }
+
+                        LocalFilter.PLAYLISTS -> {
                             item {
                                 LocalPlaceholder(filter)
                             }
@@ -349,7 +505,79 @@ fun LocalScreen(
                             }
                         }
 
-                        else -> {
+                        LocalFilter.ALBUMS -> {
+                            item(
+                                key = "header",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                albumHeaderContent()
+                            }
+
+                            albums?.let { albums ->
+                                if (albums.isEmpty()) {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.Album,
+                                            text = stringResource(R.string.library_album_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = albums,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_ALBUM }
+                                ) { _, album ->
+                                    LibraryAlbumGridItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        coroutineScope = coroutineScope,
+                                        album = album,
+                                        isActive = album.id == mediaMetadata?.album?.id,
+                                        isPlaying = isPlaying,
+                                        modifier = Modifier.animateItem()
+                                    )
+                                }
+                            }
+                        }
+
+                        LocalFilter.ARTISTS -> {
+                            item(
+                                key = "header",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                artistHeaderContent()
+                            }
+
+                            artists?.let { artists ->
+                                if (artists.isEmpty()) {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.Person,
+                                            text = stringResource(R.string.library_artist_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = artists,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_ARTIST }
+                                ) { _, artist ->
+                                    LibraryArtistGridItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        coroutineScope = coroutineScope,
+                                        modifier = Modifier.animateItem(),
+                                        artist = artist
+                                    )
+                                }
+                            }
+                        }
+
+                        LocalFilter.PLAYLISTS -> {
                             item(span = { GridItemSpan(maxLineSpan) }) {
                                 LocalPlaceholder(filter)
                             }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
@@ -1,0 +1,394 @@
+package com.dd3boh.outertune.ui.screens.library
+
+import android.content.pm.PackageManager
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.List
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.dd3boh.outertune.LocalPlayerAwareWindowInsets
+import com.dd3boh.outertune.LocalPlayerConnection
+import com.dd3boh.outertune.LocalSnackbarHostState
+import com.dd3boh.outertune.MainActivity
+import com.dd3boh.outertune.R
+import com.dd3boh.outertune.constants.CONTENT_TYPE_HEADER
+import com.dd3boh.outertune.constants.CONTENT_TYPE_SONG
+import com.dd3boh.outertune.constants.FolderSongSortType
+import com.dd3boh.outertune.constants.GridThumbnailHeight
+import com.dd3boh.outertune.constants.LibraryViewType
+import com.dd3boh.outertune.constants.ListThumbnailSize
+import com.dd3boh.outertune.constants.LocalFilter
+import com.dd3boh.outertune.constants.LocalFilterKey
+import com.dd3boh.outertune.constants.LocalLibraryEnableKey
+import com.dd3boh.outertune.constants.LocalSongSortDescendingKey
+import com.dd3boh.outertune.constants.LocalSongSortTypeKey
+import com.dd3boh.outertune.constants.LocalViewTypeKey
+import com.dd3boh.outertune.constants.SwipeToQueueKey
+import com.dd3boh.outertune.models.toMediaMetadata
+import com.dd3boh.outertune.playback.queues.ListQueue
+import com.dd3boh.outertune.ui.component.ChipsRow
+import com.dd3boh.outertune.ui.component.EmptyPlaceholder
+import com.dd3boh.outertune.ui.component.LazyColumnScrollbar
+import com.dd3boh.outertune.ui.component.LazyVerticalGridScrollbar
+import com.dd3boh.outertune.ui.component.ScrollToTopManager
+import com.dd3boh.outertune.ui.component.SortHeader
+import com.dd3boh.outertune.ui.component.button.IconButton
+import com.dd3boh.outertune.ui.component.items.SongGridItem
+import com.dd3boh.outertune.ui.component.items.SongListItem
+import com.dd3boh.outertune.ui.utils.MEDIA_PERMISSION_LEVEL
+import com.dd3boh.outertune.utils.rememberEnumPreference
+import com.dd3boh.outertune.utils.rememberPreference
+import com.dd3boh.outertune.viewmodels.LocalLibraryViewModel
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocalScreen(
+    navController: NavController,
+    viewModel: LocalLibraryViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val snackbarHostState = LocalSnackbarHostState.current
+
+    var filter by rememberEnumPreference(LocalFilterKey, LocalFilter.SONGS)
+    var viewType by rememberEnumPreference(LocalViewTypeKey, LibraryViewType.GRID)
+    val (sortType, onSortTypeChange) = rememberEnumPreference(LocalSongSortTypeKey, FolderSongSortType.TRACK_NUMBER)
+    val (sortDescending, onSortDescendingChange) = rememberPreference(LocalSongSortDescendingKey, false)
+    val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
+    val swipeEnabled by rememberPreference(SwipeToQueueKey, true)
+
+    val songs by viewModel.localSongs.collectAsState()
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+
+    val lazyListState = rememberLazyListState()
+    val lazyGridState = rememberLazyGridState()
+
+    val filterContent = @Composable {
+        var showStoragePerm by remember {
+            mutableStateOf(context.checkSelfPermission(MEDIA_PERMISSION_LEVEL) != PackageManager.PERMISSION_GRANTED)
+        }
+        Column {
+            if (localLibEnable && showStoragePerm) {
+                TextButton(
+                    onClick = {
+                        showStoragePerm = false
+                        (context as MainActivity).permissionLauncher.launch(MEDIA_PERMISSION_LEVEL)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.error)
+                ) {
+                    Text(
+                        text = stringResource(R.string.missing_media_permission_warning),
+                        color = Color.White,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
+            }
+            Row {
+                ChipsRow(
+                    chips = listOf(
+                        LocalFilter.SONGS to stringResource(R.string.songs),
+                        LocalFilter.ALBUMS to stringResource(R.string.albums),
+                        LocalFilter.ARTISTS to stringResource(R.string.artists),
+                        LocalFilter.PLAYLISTS to stringResource(R.string.playlists),
+                    ),
+                    currentValue = filter,
+                    onValueUpdate = { filter = it },
+                    modifier = Modifier.weight(1f)
+                )
+
+                IconButton(
+                    onClick = {
+                        viewType = viewType.toggle()
+                    },
+                    modifier = Modifier.padding(end = 6.dp)
+                ) {
+                    Icon(
+                        imageVector = when (viewType) {
+                            LibraryViewType.LIST -> Icons.AutoMirrored.Rounded.List
+                            LibraryViewType.GRID -> Icons.Rounded.GridView
+                        },
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+    }
+
+    val songHeaderContent = @Composable {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            SortHeader(
+                sortType = sortType,
+                sortDescending = sortDescending,
+                onSortTypeChange = onSortTypeChange,
+                onSortDescendingChange = onSortDescendingChange,
+                sortTypeText = { sortType ->
+                    when (sortType) {
+                        FolderSongSortType.CREATE_DATE -> R.string.sort_by_create_date
+                        FolderSongSortType.MODIFIED_DATE -> R.string.sort_by_date_modified
+                        FolderSongSortType.RELEASE_DATE -> R.string.sort_by_date_released
+                        FolderSongSortType.NAME -> R.string.sort_by_name
+                        FolderSongSortType.ARTIST -> R.string.sort_by_artist
+                        FolderSongSortType.PLAY_COUNT -> R.string.sort_by_play_count
+                        FolderSongSortType.TRACK_NUMBER -> R.string.sort_by_track_number
+                    }
+                }
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            songs?.let { songs ->
+                Text(
+                    text = pluralStringResource(R.plurals.n_song, songs.size, songs.size),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        ScrollToTopManager(navController, lazyListState)
+        when (viewType) {
+            LibraryViewType.LIST -> {
+                LazyColumn(
+                    state = lazyListState,
+                    contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
+                ) {
+                    item(
+                        key = "filter",
+                        contentType = CONTENT_TYPE_HEADER
+                    ) {
+                        Column(
+                            modifier = Modifier.background(MaterialTheme.colorScheme.background)
+                        ) {
+                            filterContent()
+                        }
+                    }
+
+                    when (filter) {
+                        LocalFilter.SONGS -> {
+                            item(
+                                key = "header",
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                songHeaderContent()
+                            }
+
+                            songs?.let { songs ->
+                                if (songs.isEmpty()) {
+                                    item {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.MusicNote,
+                                            text = stringResource(R.string.library_song_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                val thumbnailSize = (ListThumbnailSize.value * density.density).roundToInt()
+                                itemsIndexed(
+                                    items = songs,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_SONG }
+                                ) { index, song ->
+                                    SongListItem(
+                                        song = song,
+                                        navController = navController,
+                                        snackbarHostState = snackbarHostState,
+                                        isActive = song.song.id == mediaMetadata?.id,
+                                        isPlaying = isPlaying,
+                                        inSelectMode = false,
+                                        isSelected = false,
+                                        onSelectedChange = {},
+                                        swipeEnabled = swipeEnabled,
+                                        thumbnailSize = thumbnailSize,
+                                        onPlay = {
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = context.getString(R.string.local_files),
+                                                    items = songs.map { it.toMediaMetadata() },
+                                                    startIndex = index
+                                                )
+                                            )
+                                        },
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .animateItem()
+                                    )
+                                }
+                            }
+                        }
+
+                        else -> {
+                            item {
+                                LocalPlaceholder(filter)
+                            }
+                        }
+                    }
+                }
+                LazyColumnScrollbar(
+                    state = lazyListState,
+                )
+            }
+
+            LibraryViewType.GRID -> {
+                LazyVerticalGrid(
+                    state = lazyGridState,
+                    columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+                    contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
+                ) {
+                    item(
+                        key = "filter",
+                        span = { GridItemSpan(maxLineSpan) },
+                        contentType = CONTENT_TYPE_HEADER
+                    ) {
+                        Column(
+                            modifier = Modifier.background(MaterialTheme.colorScheme.background)
+                        ) {
+                            filterContent()
+                        }
+                    }
+
+                    when (filter) {
+                        LocalFilter.SONGS -> {
+                            item(
+                                key = "header",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                songHeaderContent()
+                            }
+
+                            songs?.let { songs ->
+                                if (songs.isEmpty()) {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        EmptyPlaceholder(
+                                            icon = Icons.Rounded.MusicNote,
+                                            text = stringResource(R.string.library_song_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = songs,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_SONG }
+                                ) { index, song ->
+                                    SongGridItem(
+                                        song = song,
+                                        isActive = song.song.id == mediaMetadata?.id,
+                                        isPlaying = isPlaying,
+                                        fillMaxWidth = true,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                playerConnection.playQueue(
+                                                    ListQueue(
+                                                        title = context.getString(R.string.local_files),
+                                                        items = songs.map { it.toMediaMetadata() },
+                                                        startIndex = index
+                                                    )
+                                                )
+                                            }
+                                            .animateItem()
+                                    )
+                                }
+                            }
+                        }
+
+                        else -> {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                LocalPlaceholder(filter)
+                            }
+                        }
+                    }
+                }
+                LazyVerticalGridScrollbar(
+                    state = lazyGridState,
+                )
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+                .align(Alignment.BottomCenter)
+        )
+    }
+}
+
+@Composable
+private fun LocalPlaceholder(filter: LocalFilter) {
+    when (filter) {
+        LocalFilter.ALBUMS -> EmptyPlaceholder(
+            icon = Icons.Rounded.Album,
+            text = stringResource(R.string.library_album_empty)
+        )
+
+        LocalFilter.ARTISTS -> EmptyPlaceholder(
+            icon = Icons.Rounded.Person,
+            text = stringResource(R.string.library_artist_empty)
+        )
+
+        LocalFilter.PLAYLISTS -> EmptyPlaceholder(
+            icon = Icons.AutoMirrored.Rounded.QueueMusic,
+            text = stringResource(R.string.library_playlist_empty)
+        )
+
+        LocalFilter.SONGS -> Unit
+    }
+}

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LocalScreen.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.ui.screens.library
 
 import android.content.pm.PackageManager
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -21,33 +22,45 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.List
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -62,6 +75,7 @@ import com.dd3boh.outertune.constants.ArtistSortType
 import com.dd3boh.outertune.constants.CONTENT_TYPE_ALBUM
 import com.dd3boh.outertune.constants.CONTENT_TYPE_ARTIST
 import com.dd3boh.outertune.constants.CONTENT_TYPE_HEADER
+import com.dd3boh.outertune.constants.CONTENT_TYPE_PLAYLIST
 import com.dd3boh.outertune.constants.CONTENT_TYPE_SONG
 import com.dd3boh.outertune.constants.FolderSongSortType
 import com.dd3boh.outertune.constants.GridThumbnailHeight
@@ -71,6 +85,9 @@ import com.dd3boh.outertune.constants.LocalAlbumSortDescendingKey
 import com.dd3boh.outertune.constants.LocalAlbumSortTypeKey
 import com.dd3boh.outertune.constants.LocalArtistSortDescendingKey
 import com.dd3boh.outertune.constants.LocalArtistSortTypeKey
+import com.dd3boh.outertune.constants.LocalPlaylistSortDescendingKey
+import com.dd3boh.outertune.constants.LocalPlaylistSortTypeKey
+import com.dd3boh.outertune.constants.PlaylistSortType
 import com.dd3boh.outertune.constants.LocalFilter
 import com.dd3boh.outertune.constants.LocalFilterKey
 import com.dd3boh.outertune.constants.LocalLibraryEnableKey
@@ -88,6 +105,8 @@ import com.dd3boh.outertune.ui.component.LibraryAlbumGridItem
 import com.dd3boh.outertune.ui.component.LibraryAlbumListItem
 import com.dd3boh.outertune.ui.component.LibraryArtistGridItem
 import com.dd3boh.outertune.ui.component.LibraryArtistListItem
+import com.dd3boh.outertune.ui.component.LibraryPlaylistGridItem
+import com.dd3boh.outertune.ui.component.LibraryPlaylistListItem
 import com.dd3boh.outertune.ui.component.ScrollToTopManager
 import com.dd3boh.outertune.ui.component.SortHeader
 import com.dd3boh.outertune.ui.component.button.IconButton
@@ -97,9 +116,12 @@ import com.dd3boh.outertune.ui.utils.MEDIA_PERMISSION_LEVEL
 import com.dd3boh.outertune.utils.rememberEnumPreference
 import com.dd3boh.outertune.utils.rememberPreference
 import com.dd3boh.outertune.viewmodels.LocalLibraryViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
 fun LocalScreen(
     navController: NavController,
@@ -120,17 +142,45 @@ fun LocalScreen(
     val (albumSortDescending, onAlbumSortDescendingChange) = rememberPreference(LocalAlbumSortDescendingKey, true)
     val (artistSortType, onArtistSortTypeChange) = rememberEnumPreference(LocalArtistSortTypeKey, ArtistSortType.CREATE_DATE)
     val (artistSortDescending, onArtistSortDescendingChange) = rememberPreference(LocalArtistSortDescendingKey, true)
+    val (playlistSortType, onPlaylistSortTypeChange) = rememberEnumPreference(LocalPlaylistSortTypeKey, PlaylistSortType.CREATE_DATE)
+    val (playlistSortDescending, onPlaylistSortDescendingChange) = rememberPreference(LocalPlaylistSortDescendingKey, true)
     val localLibEnable by rememberPreference(LocalLibraryEnableKey, defaultValue = true)
     val swipeEnabled by rememberPreference(SwipeToQueueKey, true)
 
     val songs by viewModel.localSongs.collectAsState()
     val albums by viewModel.localAlbums.collectAsState()
     val artists by viewModel.localArtists.collectAsState()
+    val playlists by viewModel.localPlaylists.collectAsState()
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
     val lazyListState = rememberLazyListState()
     val lazyGridState = rememberLazyGridState()
+
+    // search
+    var isSearching by rememberSaveable { mutableStateOf(false) }
+    var query by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue())
+    }
+    val filteredSongs = viewModel.filteredSongs
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            focusRequester.requestFocus()
+        }
+    }
+    LaunchedEffect(query) {
+        snapshotFlow { query }.debounce(300L).collectLatest {
+            viewModel.search(it.text)
+        }
+    }
+    if (isSearching) {
+        BackHandler {
+            isSearching = false
+            query = TextFieldValue()
+        }
+    }
 
     val filterContent = @Composable {
         var showStoragePerm by remember {
@@ -154,32 +204,79 @@ fun LocalScreen(
                     )
                 }
             }
-            Row {
-                ChipsRow(
-                    chips = listOf(
-                        LocalFilter.SONGS to stringResource(R.string.songs),
-                        LocalFilter.ALBUMS to stringResource(R.string.albums),
-                        LocalFilter.ARTISTS to stringResource(R.string.artists),
-                        LocalFilter.PLAYLISTS to stringResource(R.string.playlists),
-                    ),
-                    currentValue = filter,
-                    onValueUpdate = { filter = it },
-                    modifier = Modifier.weight(1f)
-                )
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (isSearching) {
+                    TextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        placeholder = {
+                            Text(
+                                text = stringResource(R.string.search),
+                                style = MaterialTheme.typography.titleLarge
+                            )
+                        },
+                        singleLine = true,
+                        textStyle = MaterialTheme.typography.titleLarge,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent,
+                        ),
+                        modifier = Modifier
+                            .weight(1f)
+                            .focusRequester(focusRequester)
+                    )
+                } else {
+                    ChipsRow(
+                        chips = listOf(
+                            LocalFilter.SONGS to stringResource(R.string.songs),
+                            LocalFilter.ALBUMS to stringResource(R.string.albums),
+                            LocalFilter.ARTISTS to stringResource(R.string.artists),
+                            LocalFilter.PLAYLISTS to stringResource(R.string.playlists),
+                        ),
+                        currentValue = filter,
+                        onValueUpdate = { filter = it },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
 
                 IconButton(
                     onClick = {
-                        viewType = viewType.toggle()
+                        if (isSearching) {
+                            isSearching = false
+                            query = TextFieldValue()
+                        } else {
+                            isSearching = true
+                        }
                     },
-                    modifier = Modifier.padding(end = 6.dp)
+                    modifier = Modifier.padding(end = if (isSearching) 6.dp else 0.dp)
                 ) {
                     Icon(
-                        imageVector = when (viewType) {
-                            LibraryViewType.LIST -> Icons.AutoMirrored.Rounded.List
-                            LibraryViewType.GRID -> Icons.Rounded.GridView
-                        },
+                        imageVector = if (isSearching) Icons.Rounded.Close else Icons.Rounded.Search,
                         contentDescription = null
                     )
+                }
+
+                if (!isSearching) {
+                    IconButton(
+                        onClick = {
+                            viewType = viewType.toggle()
+                        },
+                        modifier = Modifier.padding(end = 6.dp)
+                    ) {
+                        Icon(
+                            imageVector = when (viewType) {
+                                LibraryViewType.LIST -> Icons.AutoMirrored.Rounded.List
+                                LibraryViewType.GRID -> Icons.Rounded.GridView
+                            },
+                            contentDescription = null
+                        )
+                    }
                 }
             }
         }
@@ -285,11 +382,93 @@ fun LocalScreen(
         }
     }
 
+    val playlistHeaderContent = @Composable {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            SortHeader(
+                sortType = playlistSortType,
+                sortDescending = playlistSortDescending,
+                onSortTypeChange = onPlaylistSortTypeChange,
+                onSortDescendingChange = onPlaylistSortDescendingChange,
+                sortTypeText = { sortType ->
+                    when (sortType) {
+                        PlaylistSortType.CREATE_DATE -> R.string.sort_by_create_date
+                        PlaylistSortType.NAME -> R.string.sort_by_name
+                        PlaylistSortType.SONG_COUNT -> R.string.sort_by_song_count
+                    }
+                }
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            playlists?.let { playlists ->
+                Text(
+                    text = pluralStringResource(R.plurals.n_playlist, playlists.size, playlists.size),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
         ScrollToTopManager(navController, lazyListState)
-        when (viewType) {
+        if (isSearching) {
+            LazyColumn(
+                state = lazyListState,
+                contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
+            ) {
+                item(
+                    key = "filter",
+                    contentType = CONTENT_TYPE_HEADER
+                ) {
+                    Column(
+                        modifier = Modifier.background(MaterialTheme.colorScheme.background)
+                    ) {
+                        filterContent()
+                    }
+                }
+
+                val thumbnailSize = (ListThumbnailSize.value * density.density).roundToInt()
+                itemsIndexed(
+                    items = filteredSongs,
+                    key = { _, item -> item.id },
+                    contentType = { _, _ -> CONTENT_TYPE_SONG }
+                ) { index, song ->
+                    SongListItem(
+                        song = song,
+                        navController = navController,
+                        snackbarHostState = snackbarHostState,
+                        isActive = song.song.id == mediaMetadata?.id,
+                        isPlaying = isPlaying,
+                        inSelectMode = false,
+                        isSelected = false,
+                        onSelectedChange = {},
+                        swipeEnabled = swipeEnabled,
+                        thumbnailSize = thumbnailSize,
+                        onPlay = {
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = context.getString(R.string.local_files),
+                                    items = filteredSongs.map { it.toMediaMetadata() },
+                                    startIndex = index
+                                )
+                            )
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateItem()
+                    )
+                }
+            }
+            LazyColumnScrollbar(
+                state = lazyListState,
+            )
+        } else when (viewType) {
             LibraryViewType.LIST -> {
                 LazyColumn(
                     state = lazyListState,
@@ -429,8 +608,36 @@ fun LocalScreen(
                         }
 
                         LocalFilter.PLAYLISTS -> {
-                            item {
-                                LocalPlaceholder(filter)
+                            item(
+                                key = "header",
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                playlistHeaderContent()
+                            }
+
+                            playlists?.let { playlists ->
+                                if (playlists.isEmpty()) {
+                                    item {
+                                        EmptyPlaceholder(
+                                            icon = Icons.AutoMirrored.Rounded.QueueMusic,
+                                            text = stringResource(R.string.library_playlist_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = playlists,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_PLAYLIST }
+                                ) { _, playlist ->
+                                    LibraryPlaylistListItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        coroutineScope = coroutineScope,
+                                        playlist = playlist,
+                                        modifier = Modifier.animateItem()
+                                    )
+                                }
                             }
                         }
                     }
@@ -578,8 +785,37 @@ fun LocalScreen(
                         }
 
                         LocalFilter.PLAYLISTS -> {
-                            item(span = { GridItemSpan(maxLineSpan) }) {
-                                LocalPlaceholder(filter)
+                            item(
+                                key = "header",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER
+                            ) {
+                                playlistHeaderContent()
+                            }
+
+                            playlists?.let { playlists ->
+                                if (playlists.isEmpty()) {
+                                    item(span = { GridItemSpan(maxLineSpan) }) {
+                                        EmptyPlaceholder(
+                                            icon = Icons.AutoMirrored.Rounded.QueueMusic,
+                                            text = stringResource(R.string.library_playlist_empty),
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
+                                itemsIndexed(
+                                    items = playlists,
+                                    key = { _, item -> item.id },
+                                    contentType = { _, _ -> CONTENT_TYPE_PLAYLIST }
+                                ) { _, playlist ->
+                                    LibraryPlaylistGridItem(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        coroutineScope = coroutineScope,
+                                        playlist = playlist,
+                                        modifier = Modifier.animateItem()
+                                    )
+                                }
                             }
                         }
                     }
@@ -596,27 +832,5 @@ fun LocalScreen(
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
                 .align(Alignment.BottomCenter)
         )
-    }
-}
-
-@Composable
-private fun LocalPlaceholder(filter: LocalFilter) {
-    when (filter) {
-        LocalFilter.ALBUMS -> EmptyPlaceholder(
-            icon = Icons.Rounded.Album,
-            text = stringResource(R.string.library_album_empty)
-        )
-
-        LocalFilter.ARTISTS -> EmptyPlaceholder(
-            icon = Icons.Rounded.Person,
-            text = stringResource(R.string.library_artist_empty)
-        )
-
-        LocalFilter.PLAYLISTS -> EmptyPlaceholder(
-            icon = Icons.AutoMirrored.Rounded.QueueMusic,
-            text = stringResource(R.string.library_playlist_empty)
-        )
-
-        LocalFilter.SONGS -> Unit
     }
 }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/ArtistAlbumsViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/ArtistAlbumsViewModel.kt
@@ -18,6 +18,6 @@ class ArtistAlbumsViewModel @Inject constructor(
     val artist = database.artist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
-    val albums = database.artistAlbumsPreview(artistId)
+    val albums = database.artistAlbums(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/ArtistViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dd3boh.outertune.constants.ArtistSongSortType
 import com.dd3boh.outertune.db.MusicDatabase
 import com.dd3boh.outertune.utils.reportException
 import com.zionhuang.innertube.YouTube
@@ -26,7 +27,7 @@ class ArtistViewModel @Inject constructor(
     var artistPage by mutableStateOf<ArtistPage?>(null)
     val libraryArtist = database.artist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
-    val librarySongs = database.artistSongsPreview(artistId)
+    val librarySongs = database.artistSongs(artistId, ArtistSongSortType.CREATE_DATE, descending = true)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
     val libraryAlbums = database.artistAlbumsPreview(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
@@ -161,7 +161,22 @@ class LocalLibraryViewModel @Inject constructor(
         }
         .distinctUntilChanged()
         .flatMapLatest { (sortType, descending) ->
-            database.artists(ArtistFilter.LIBRARY, sortType, descending, localOnly = true)
+            combine(
+                database.artists(ArtistFilter.LIBRARY, sortType, descending, localOnly = true),
+                database.localArtistThumbnails(),
+            ) { artists, thumbnails ->
+                val thumbnailByArtist = thumbnails
+                    .filter { it.thumbnailUrl != null }
+                    .associate { it.artistId to it.thumbnailUrl }
+                artists.map { artist ->
+                    val fallback = thumbnailByArtist[artist.id]
+                    if (artist.artist.isLocal && artist.artist.thumbnailUrl == null && fallback != null) {
+                        artist.copy(artist = artist.artist.copy(thumbnailUrl = fallback))
+                    } else {
+                        artist
+                    }
+                }
+            }
         }
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
@@ -30,9 +30,12 @@ import com.dd3boh.outertune.constants.ArtistSongSortTypeKey
 import com.dd3boh.outertune.constants.ArtistSortDescendingKey
 import com.dd3boh.outertune.constants.ArtistSortType
 import com.dd3boh.outertune.constants.ArtistSortTypeKey
+import com.dd3boh.outertune.constants.FolderSongSortType
 import com.dd3boh.outertune.constants.LibrarySortDescendingKey
 import com.dd3boh.outertune.constants.LibrarySortType
 import com.dd3boh.outertune.constants.LibrarySortTypeKey
+import com.dd3boh.outertune.constants.LocalSongSortDescendingKey
+import com.dd3boh.outertune.constants.LocalSongSortTypeKey
 import com.dd3boh.outertune.constants.PlaylistFilter
 import com.dd3boh.outertune.constants.PlaylistFilterKey
 import com.dd3boh.outertune.constants.PlaylistSortDescendingKey
@@ -55,6 +58,7 @@ import com.dd3boh.outertune.ui.utils.cacheDirectoryTree
 import com.dd3boh.outertune.ui.utils.getDirectoryTree
 import com.dd3boh.outertune.utils.SyncUtils
 import com.dd3boh.outertune.utils.dataStore
+import com.dd3boh.outertune.utils.numberToAlpha
 import com.dd3boh.outertune.utils.reportException
 import com.dd3boh.outertune.utils.scanners.LocalMediaScanner.Companion.refreshLocal
 import com.zionhuang.innertube.YouTube
@@ -74,6 +78,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import javax.inject.Inject
 
 @HiltViewModel
@@ -112,6 +117,43 @@ class LibrarySongsViewModel @Inject constructor(
                     SongFilter.DOWNLOADED -> database.downloadSongs(sortType, descending)
                 }
             }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+    }
+}
+
+@HiltViewModel
+class LocalLibraryViewModel @Inject constructor(
+    @ApplicationContext context: Context,
+    database: MusicDatabase,
+) : ViewModel() {
+    val localSongs: StateFlow<List<Song>?> = combine(
+        database.allLocalSongsFlow(),
+        context.dataStore.data
+            .map {
+                it[LocalSongSortTypeKey].toEnum(FolderSongSortType.TRACK_NUMBER) to
+                        (it[LocalSongSortDescendingKey] == true)
+            }
+            .distinctUntilChanged()
+    ) { songs, (sortType, descending) ->
+        sortLocalSongs(songs, sortType, descending)
+    }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    private fun sortLocalSongs(
+        songs: List<Song>,
+        sortType: FolderSongSortType,
+        descending: Boolean,
+    ): List<Song> {
+        val sorted = songs.sortedBy {
+            when (sortType) {
+                FolderSongSortType.CREATE_DATE -> numberToAlpha(it.song.inLibrary?.toEpochSecond(ZoneOffset.UTC) ?: -1L)
+                FolderSongSortType.MODIFIED_DATE -> numberToAlpha(it.song.getDateModifiedLong() ?: -1L)
+                FolderSongSortType.RELEASE_DATE -> numberToAlpha(it.song.getDateLong() ?: -1L)
+                FolderSongSortType.NAME -> it.song.title.lowercase()
+                FolderSongSortType.ARTIST -> it.artists.joinToString { artist -> artist.name }.lowercase()
+                FolderSongSortType.PLAY_COUNT -> numberToAlpha((it.playCount?.sumOf { pc -> pc.count })?.toLong() ?: 0L)
+                FolderSongSortType.TRACK_NUMBER -> numberToAlpha(it.song.trackNumber?.toLong() ?: Long.MAX_VALUE)
+            }
+        }
+        return if (descending) sorted.reversed() else sorted
     }
 }
 

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
@@ -34,6 +34,10 @@ import com.dd3boh.outertune.constants.FolderSongSortType
 import com.dd3boh.outertune.constants.LibrarySortDescendingKey
 import com.dd3boh.outertune.constants.LibrarySortType
 import com.dd3boh.outertune.constants.LibrarySortTypeKey
+import com.dd3boh.outertune.constants.LocalAlbumSortDescendingKey
+import com.dd3boh.outertune.constants.LocalAlbumSortTypeKey
+import com.dd3boh.outertune.constants.LocalArtistSortDescendingKey
+import com.dd3boh.outertune.constants.LocalArtistSortTypeKey
 import com.dd3boh.outertune.constants.LocalSongSortDescendingKey
 import com.dd3boh.outertune.constants.LocalSongSortTypeKey
 import com.dd3boh.outertune.constants.PlaylistFilter
@@ -136,6 +140,26 @@ class LocalLibraryViewModel @Inject constructor(
     ) { songs, (sortType, descending) ->
         sortLocalSongs(songs, sortType, descending)
     }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val localAlbums: StateFlow<List<Album>?> = context.dataStore.data
+        .map {
+            it[LocalAlbumSortTypeKey].toEnum(AlbumSortType.CREATE_DATE) to (it[LocalAlbumSortDescendingKey] ?: true)
+        }
+        .distinctUntilChanged()
+        .flatMapLatest { (sortType, descending) ->
+            database.albums(AlbumFilter.LIBRARY, sortType, descending, localOnly = true)
+        }
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val localArtists: StateFlow<List<Artist>?> = context.dataStore.data
+        .map {
+            it[LocalArtistSortTypeKey].toEnum(ArtistSortType.CREATE_DATE) to (it[LocalArtistSortDescendingKey] ?: true)
+        }
+        .distinctUntilChanged()
+        .flatMapLatest { (sortType, descending) ->
+            database.artists(ArtistFilter.LIBRARY, sortType, descending, localOnly = true)
+        }
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     private fun sortLocalSongs(
         songs: List<Song>,

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
@@ -38,6 +38,8 @@ import com.dd3boh.outertune.constants.LocalAlbumSortDescendingKey
 import com.dd3boh.outertune.constants.LocalAlbumSortTypeKey
 import com.dd3boh.outertune.constants.LocalArtistSortDescendingKey
 import com.dd3boh.outertune.constants.LocalArtistSortTypeKey
+import com.dd3boh.outertune.constants.LocalPlaylistSortDescendingKey
+import com.dd3boh.outertune.constants.LocalPlaylistSortTypeKey
 import com.dd3boh.outertune.constants.LocalSongSortDescendingKey
 import com.dd3boh.outertune.constants.LocalSongSortTypeKey
 import com.dd3boh.outertune.constants.PlaylistFilter
@@ -127,8 +129,10 @@ class LibrarySongsViewModel @Inject constructor(
 @HiltViewModel
 class LocalLibraryViewModel @Inject constructor(
     @ApplicationContext context: Context,
-    database: MusicDatabase,
+    private val database: MusicDatabase,
 ) : ViewModel() {
+    val filteredSongs = mutableStateListOf<Song>()
+
     val localSongs: StateFlow<List<Song>?> = combine(
         database.allLocalSongsFlow(),
         context.dataStore.data
@@ -160,6 +164,28 @@ class LocalLibraryViewModel @Inject constructor(
             database.artists(ArtistFilter.LIBRARY, sortType, descending, localOnly = true)
         }
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val localPlaylists: StateFlow<List<Playlist>?> = context.dataStore.data
+        .map {
+            it[LocalPlaylistSortTypeKey].toEnum(PlaylistSortType.CREATE_DATE) to (it[LocalPlaylistSortDescendingKey] ?: true)
+        }
+        .distinctUntilChanged()
+        .flatMapLatest { (sortType, descending) ->
+            database.playlists(PlaylistFilter.LIBRARY, sortType, descending, variant = 0, localSongsOnly = true)
+        }
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    fun search(query: String) {
+        if (query.isBlank()) {
+            filteredSongs.clear()
+            return
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            val result = database.searchSongsAllLocal(query).first()
+            filteredSongs.clear()
+            filteredSongs.addAll(result)
+        }
+    }
 
     private fun sortLocalSongs(
         songs: List<Song>,

--- a/app/src/main/res/values-ja/strings-ot.xml
+++ b/app/src/main/res/values-ja/strings-ot.xml
@@ -53,6 +53,7 @@
     <string name="scanner_auto_start">ローカルメディアと楽曲ダウンロードフォルダを更新しています…</string>
     <string name="scanner_progress_scanning">スキャン中…</string>
     <string name="folders">フォルダ</string>
+    <string name="local_files">ローカル</string>
     <string name="recent_activity">最近のアクティビティ</string>
     <string name="remote_history">リモート</string>
     <string name="delete_lyric_confirm">\"%s\"の保存された歌詞を本当に削除しますか？</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -9,6 +9,7 @@ while also allowing users to translate our app as well. New, specific strings to
 
 <!-- Bottom navigation -->
     <string name="folders">Folders</string>
+    <string name="local_files">Local</string>
     <string name="library">Library</string>
 
 <!-- Home -->


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Add a "Local" tab for browsing on-device music, and extend the artist screen to show a local artist's full library.

- Add a "Local" bottom-navigation tab that lists on-device songs.
- Provide filter chips for songs, albums, artists, and playlists, with a list/grid toggle and per-filter sorting.
- Search across all local songs, regardless of the selected filter.
- Limit the playlist filter to playlists composed only of local songs, including empty ones.
- Show representative artwork for local artists (a local album cover, falling back to a local song's embedded artwork).
- On the artist screen's local view, list every song for the artist, ordered by most recently added.
- Show every album on the artist albums screen.

### Before/After Screenshots/Screen Record

<img width="274" height="640" alt="Screenshot_20260707-205135" src="https://github.com/user-attachments/assets/05685bf9-a299-411a-a59a-b6427f7ecf05" />


### Fixes the following issue(s)

- Fixes: #45 

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed