### PR TITLE
fix: size Home recent activity cards to the content area width

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/component/items/Items.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/items/Items.kt
@@ -64,13 +64,13 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.exoplayer.offline.Download.STATE_COMPLETED
 import androidx.media3.exoplayer.offline.Download.STATE_DOWNLOADING
@@ -572,19 +572,17 @@ fun YouTubeGridItem(
 @Composable
 fun YouTubeCardItem(
     item: RecentActivityEntity,
+    width: Dp,
     modifier: Modifier = Modifier,
     isActive: Boolean,
     isPlaying: Boolean,
     onClick: () -> Unit,
 ) {
-    val configuration = LocalConfiguration.current
-    val screenWidthDp = configuration.screenWidthDp
-
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .height(60.dp)
-            .width((screenWidthDp.dp - 12.dp) / 2)
+            .width(width)
             .padding(6.dp)
             .clip(RoundedCornerShape(6.dp))
             .background(MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp))

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -352,6 +352,7 @@ fun HomeScreen(
 
         val horizontalLazyGridItemWidthFactor = if (maxWidth * 0.475f >= 320.dp) 0.475f else 0.9f
         val horizontalLazyGridItemWidth = maxWidth * horizontalLazyGridItemWidthFactor
+        val recentActivityItemWidth = (maxWidth - 12.dp) / 2
         val quickPicksSnapLayoutInfoProvider = remember(quickPicksLazyGridState) {
             SnapLayoutInfoProvider(
                 lazyGridState = quickPicksLazyGridState,
@@ -419,6 +420,7 @@ fun HomeScreen(
                         ) { item ->
                             YouTubeCardItem(
                                 item = item,
+                                width = recentActivityItemWidth,
                                 isActive = when (item.type) {
                                     RecentActivityType.PLAYLIST -> queuePlaylistId == item.id
                                     RecentActivityType.ALBUM -> queuePlaylistId == item.playlistId


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Each Home "Recent activity" card was sized from the full device screen width, which is about as wide as the whole content area in the tablet split layout (player side pane + content). As a result the first column took up almost all of the horizontal space and pushed the next column nearly off-screen.
- Size the cards from the Home content area width instead, so the columns fit within the content area. The phone layout is unchanged.

Tested on a phone (portrait) and a tablet (landscape split layout): recent activity fits two columns within the content area, and card tap navigation (playlist / album / artist) and the playing indicator behave as before.

### Before/After Screenshots/Screen Record

- Before: On tablets, recent activity cards were too wide; the first column took up almost all of the horizontal space and the next column was pushed nearly off-screen.


<img width="640" height="400" alt="tablet_home" src="https://github.com/user-attachments/assets/702754f7-5936-438c-8123-9c720e496739" />


- After: Cards fit the content area, showing two columns.

<img width="640" height="400" alt="Screenshot_20260708_142353" src="https://github.com/user-attachments/assets/1e72734f-9731-4d9e-b8f6-c305aec674fc" />

### Fixes the following issue(s)

- N/A

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)