### PR TITLE
fix: YouTube Music history reporting

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -137,8 +137,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -1139,8 +1139,18 @@ class MusicService : MediaLibraryService(),
                 val ytHist = mediaItem.metadata?.isLocal != true && !dataStore.get(PauseRemoteListenHistoryKey, false)
                 if (SERVICE_DEBUG) Log.d(TAG, "Trying to register remote history: $ytHist")
                 if (ytHist) {
-                    val playbackUrl = YTPlayerUtils.playerResponseForMetadata(mediaItem.mediaId, null)
-                        .getOrNull()?.playbackTracking?.videostatsPlaybackUrl?.baseUrl
+                    val metaResult = YTPlayerUtils.playerResponseForMetadata(mediaItem.mediaId, null)
+                    val response = metaResult.getOrNull()
+                    if (SERVICE_DEBUG) Log.d(
+                        TAG,
+                        "History meta: success=${metaResult.isSuccess}" +
+                            (metaResult.exceptionOrNull()?.let { " err=${it.javaClass.simpleName}:${it.message}" } ?: "") +
+                            " playability=${response?.playabilityStatus?.status}/${response?.playabilityStatus?.reason}" +
+                            " hasTracking=${response?.playbackTracking != null}" +
+                            " hasVideostats=${response?.playbackTracking?.videostatsPlaybackUrl != null}" +
+                            " loggedIn=${YouTube.cookie != null}"
+                    )
+                    val playbackUrl = response?.playbackTracking?.videostatsPlaybackUrl?.baseUrl
                     if (SERVICE_DEBUG) Log.d(TAG, "Got playback url: $playbackUrl")
                     playbackUrl?.let {
                         YouTube.registerPlayback(null, playbackUrl)

--- a/app/src/main/java/com/dd3boh/outertune/utils/YTPlayerUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/YTPlayerUtils.kt
@@ -219,14 +219,23 @@ object YTPlayerUtils {
     }
 
     /**
-     * Simple player response intended to use for metadata only.
-     * Stream URLs of this response might not work so don't use them.
+     * Fetches a WEB_REMIX player response for non-streaming data, including
+     * video metadata and playback tracking.
+     *
+     * Streaming URLs from this response are not guaranteed to be playable.
      */
     suspend fun playerResponseForMetadata(
         videoId: String,
         playlistId: String? = null,
-    ): Result<PlayerResponse> =
-        YouTube.player(videoId, playlistId, client = WEB_REMIX) // ANDROID_VR does not work with history
+    ): Result<PlayerResponse> {
+        // WEB_REMIX provides the playback tracking URL required for history registration.
+        // Include the web player integrity fields because omitting the player PoToken may
+        // cause the request to return UNPLAYABLE.
+        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
+        val sessionId = if (YouTube.cookie != null) YouTube.dataSyncId else YouTube.visitorData
+        val webPlayerPot = getWebClientPoTokenOrNull(videoId, sessionId)?.playerRequestPoToken
+        return YouTube.player(videoId, playlistId, WEB_REMIX, signatureTimestamp, webPlayerPot)
+    }
 
     private fun findFormat(
         playerResponse: PlayerResponse,


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Fix YouTube Music history reporting for played songs
- Generate a session-specific web player PoToken using `dataSyncId` for signed-in sessions or `visitorData` for signed-out sessions
- Pass the player request PoToken and signature timestamp to the `WEB_REMIX` player request
- Retrieve the playback tracking URL required by `registerPlayback`
- Add debug-only logging for player response failures, playability status, and playback tracking availability
- Verified on a physical Android device that playback history is sent to YouTube Music

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)