### PR TITLE
feat: always show the View album menu item

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
@@ -315,15 +315,14 @@ fun PlayerMenu(
                 showSelectArtistDialog = true
             }
         }
-        if (mediaMetadata.album != null && !mediaMetadata.isLocal) {
-            GridMenuItem(
-                icon = R.drawable.album,
-                title = R.string.view_album
-            ) {
-                navController.navigate("album/${mediaMetadata.album.id}")
-                playerBottomSheetState.collapseSoft()
-                onDismiss()
-            }
+        GridMenuItem(
+            icon = R.drawable.album,
+            title = R.string.view_album,
+            enabled = mediaMetadata.album != null && !mediaMetadata.isLocal
+        ) {
+            mediaMetadata.album?.let { navController.navigate("album/${it.id}") }
+            playerBottomSheetState.collapseSoft()
+            onDismiss()
         }
 
         if (!mediaMetadata.isLocal)


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Previously the "View album" item was removed from the player menu when a song had no album or was a local file. This shifted the items below it up by one cell, so items at the end of the menu could be pushed off screen.

- The "View album" item is now always shown, and disabled (greyed out) when the song has no album or is a local file, instead of being removed.
- With the item's position fixed, the items below it no longer shift, and menu items are no longer pushed off screen for songs without an album.

### Before/After Screenshots/Screen Record

- Before:
- After:

## Due diligence

- [x] I have read and agreed to the contribution guidelines.

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase, or squash my code, or apply merge conflict amendments as needed
