### PR TITLE
feat: make showing lyrics on artwork tap optional

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -87,6 +87,7 @@ val SleepTimerShowOnPlayerKey = booleanPreferencesKey("sleepTimerShowOnPlayer")
  * Lyrics
  */
 val ShowLyricsKey = booleanPreferencesKey("showLyrics")
+val ShowLyricsOnClickKey = booleanPreferencesKey("showLyricsOnClick")
 val LyricsTextPositionKey = stringPreferencesKey("lyricsTextPosition")
 val MultilineLrcKey = booleanPreferencesKey("multilineLrc")
 val LyricTrimKey = booleanPreferencesKey("lyricTrim")

--- a/app/src/main/java/com/dd3boh/outertune/constants/Settings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/Settings.kt
@@ -38,6 +38,7 @@ enum class LyricsPosition {
 const val DEFAULT_ENABLED_TABS = "HSFOM"
 const val DEFAULT_ENABLED_FILTERS = "ARP"
 const val DEFAULT_SWIPE_TO_SKIP = true
+const val DEFAULT_SHOW_LYRICS_ON_CLICK = true
 
 /*
 ---------------------------

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -127,12 +127,14 @@ import com.dd3boh.outertune.constants.PlayerBackgroundStyleKey
 import com.dd3boh.outertune.constants.PLAYER_DEBUG
 import com.dd3boh.outertune.constants.PlayerHorizontalPadding
 import com.dd3boh.outertune.constants.QueuePeekHeight
+import com.dd3boh.outertune.constants.DEFAULT_SHOW_LYRICS_ON_CLICK
 import com.dd3boh.outertune.constants.DEFAULT_SLIDER_STYLE
 import com.dd3boh.outertune.constants.DEFAULT_SWIPE_TO_SKIP
 import com.dd3boh.outertune.constants.SeekIncrement
 import com.dd3boh.outertune.constants.SeekIncrementKey
 import com.dd3boh.outertune.constants.SliderStyleKey
 import com.dd3boh.outertune.constants.ShowLyricsKey
+import com.dd3boh.outertune.constants.ShowLyricsOnClickKey
 import com.dd3boh.outertune.constants.SleepTimerShowOnPlayerKey
 import com.dd3boh.outertune.constants.SwipeToSkipKey
 import com.dd3boh.outertune.extensions.isPowerSaver
@@ -274,6 +276,7 @@ fun PortraitPlayer(
             val canSkipNext by playerConnection.canSkipNext.collectAsState()
 
             val swipeToSkip by rememberPreference(SwipeToSkipKey, defaultValue = DEFAULT_SWIPE_TO_SKIP)
+            val showLyricsOnClick by rememberPreference(ShowLyricsOnClickKey, defaultValue = DEFAULT_SHOW_LYRICS_ON_CLICK)
             val previousMediaMetadata = if (swipeToSkip && playerConnection.player.hasPreviousMediaItem()) {
                 val previousIndex = playerConnection.player.previousMediaItemIndex
                 playerConnection.player.getMediaItemAt(previousIndex).metadata
@@ -300,7 +303,7 @@ fun PortraitPlayer(
 //                                .width(horizontalLazyGridItemWidth)
                         .animateContentSize(),
                     sliderPositionProvider = { sliderPosition },
-                    showLyricsOnClick = true,
+                    showLyricsOnClick = showLyricsOnClick,
                     customMediaMetadata = mediaMetadata
                 )
             } else {
@@ -355,7 +358,7 @@ fun PortraitPlayer(
                                 .width(horizontalLazyGridItemWidth)
                                 .animateContentSize(),
                             sliderPositionProvider = { sliderPosition },
-                            showLyricsOnClick = true,
+                            showLyricsOnClick = showLyricsOnClick,
                             customMediaMetadata = it
                         )
                     }
@@ -404,6 +407,7 @@ fun LandscapePlayer(
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
 
     val swipeToSkip by rememberPreference(SwipeToSkipKey, defaultValue = DEFAULT_SWIPE_TO_SKIP)
+    val showLyricsOnClick by rememberPreference(ShowLyricsOnClickKey, defaultValue = DEFAULT_SHOW_LYRICS_ON_CLICK)
     val previousMediaMetadata = if (swipeToSkip && playerConnection.player.hasPreviousMediaItem()) {
         val previousIndex = playerConnection.player.previousMediaItemIndex
         playerConnection.player.getMediaItemAt(previousIndex).metadata
@@ -458,7 +462,7 @@ fun LandscapePlayer(
                     modifier = Modifier
 //                                .width(horizontalLazyGridItemWidth)
                         .animateContentSize(),
-                    showLyricsOnClick = true,
+                    showLyricsOnClick = showLyricsOnClick,
                     customMediaMetadata = mediaMetadata
                 )
             } else {
@@ -514,7 +518,7 @@ fun LandscapePlayer(
                             modifier = Modifier
                                 .width(horizontalLazyGridItemWidth)
                                 .animateContentSize(),
-                            showLyricsOnClick = true,
+                            showLyricsOnClick = showLyricsOnClick,
                             customMediaMetadata = it
                         )
                     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/InterfaceSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/InterfaceSettings.kt
@@ -40,7 +40,7 @@ import com.dd3boh.outertune.ui.component.ColumnWithContentPadding
 import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.PreferenceGroupTitle
 import com.dd3boh.outertune.ui.component.button.IconButton
-import com.dd3boh.outertune.ui.screens.settings.fragments.SwipeGesturesFrag
+import com.dd3boh.outertune.ui.screens.settings.fragments.GestureSettingsFrag
 import com.dd3boh.outertune.ui.screens.settings.fragments.TabArrangementFrag
 import com.dd3boh.outertune.ui.screens.settings.fragments.TabExtrasFrag
 import com.dd3boh.outertune.ui.utils.backToMain
@@ -83,7 +83,7 @@ fun InterfaceSettings(
         ElevatedCard(
             modifier = Modifier.fillMaxWidth()
         ) {
-            SwipeGesturesFrag()
+            GestureSettingsFrag()
         }
         Spacer(modifier = Modifier.height(48.dp))
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/InterfaceFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/InterfaceFrag.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material.icons.rounded.Language
 import androidx.compose.material.icons.rounded.LocationOn
+import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.Reorder
 import androidx.compose.material.icons.rounded.Swipe
 import androidx.compose.material.icons.rounded.Tab
@@ -46,12 +47,14 @@ import com.dd3boh.outertune.constants.ContentLanguageKey
 import com.dd3boh.outertune.constants.CountryCodeToName
 import com.dd3boh.outertune.constants.DEFAULT_ENABLED_FILTERS
 import com.dd3boh.outertune.constants.DEFAULT_ENABLED_TABS
+import com.dd3boh.outertune.constants.DEFAULT_SHOW_LYRICS_ON_CLICK
 import com.dd3boh.outertune.constants.DEFAULT_SWIPE_TO_SKIP
 import com.dd3boh.outertune.constants.DefaultOpenTabKey
 import com.dd3boh.outertune.constants.EnabledFiltersKey
 import com.dd3boh.outertune.constants.EnabledTabsKey
 import com.dd3boh.outertune.constants.LanguageCodeToName
 import com.dd3boh.outertune.constants.ListItemHeight
+import com.dd3boh.outertune.constants.ShowLyricsOnClickKey
 import com.dd3boh.outertune.constants.SYSTEM_DEFAULT
 import com.dd3boh.outertune.constants.SwipeToQueueKey
 import com.dd3boh.outertune.constants.SwipeToSkipKey
@@ -395,9 +398,13 @@ fun ColumnScope.TabExtrasFrag() {
 }
 
 @Composable
-fun ColumnScope.SwipeGesturesFrag() {
+fun ColumnScope.GestureSettingsFrag() {
     val (swipeToSkip, onSwipeToSkipChange) = rememberPreference(SwipeToSkipKey, defaultValue = DEFAULT_SWIPE_TO_SKIP)
     val (swipe2Queue, onSwipe2QueueChange) = rememberPreference(SwipeToQueueKey, defaultValue = true)
+    val (showLyricsOnClick, onShowLyricsOnClickChange) = rememberPreference(
+        ShowLyricsOnClickKey,
+        defaultValue = DEFAULT_SHOW_LYRICS_ON_CLICK
+    )
 
     SwitchPreference(
         title = { Text(stringResource(R.string.swipe2Queue)) },
@@ -412,6 +419,13 @@ fun ColumnScope.SwipeGesturesFrag() {
         icon = { Icon(Icons.Rounded.Swipe, null) },
         checked = swipeToSkip,
         onCheckedChange = onSwipeToSkipChange
+    )
+    SwitchPreference(
+        title = { Text(stringResource(R.string.tap_artwork_to_show_lyrics_title)) },
+        description = stringResource(R.string.tap_artwork_to_show_lyrics_description),
+        icon = { Icon(Icons.Rounded.Lyrics, null) },
+        checked = showLyricsOnClick,
+        onCheckedChange = onShowLyricsOnClickChange
     )
 }
 
@@ -489,9 +503,9 @@ private fun TabExtrasFragPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun SwipeGesturesFragPreview() {
+private fun GestureSettingsFragPreview() {
     Column {
-        SwipeGesturesFrag()
+        GestureSettingsFrag()
     }
 }
 

--- a/app/src/main/res/values-ja/strings-ot.xml
+++ b/app/src/main/res/values-ja/strings-ot.xml
@@ -163,6 +163,8 @@
     <string name="filter_arrangement">フィルターの配置</string>
     <string name="swipe_to_skip_title">再生中に横スワイプで曲を変更</string>
     <string name="swipe_to_skip_description">プレーヤー内で水平にスワイプして曲を切り替える</string>
+    <string name="tap_artwork_to_show_lyrics_title">アートワークをタップして歌詞を表示</string>
+    <string name="tap_artwork_to_show_lyrics_description">プレーヤーのアートワークをタップしたときに歌詞を表示します</string>
     <string name="restart_to_apply_changes">変更を反映するには、アプリを再起動してください</string>
     <string name="missing_media_permission_warning">端末内のメディアに対するストレージの権限が必要です。クリックし権限を付与してください。</string>
     <string name="more_settings">その他の設定</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -315,6 +315,9 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="swipe_to_skip_title">Swipe horizontally to change song</string>
     <string name="swipe_to_skip_description">Enable swiping horizontally in the player to switch songs</string>
 
+    <string name="tap_artwork_to_show_lyrics_title">Tap artwork to show lyrics</string>
+    <string name="tap_artwork_to_show_lyrics_description">Show lyrics when tapping the artwork in the player</string>
+
     <string name="max_queues_title">Maximum number of queues</string>
 
 <!-- Setup wizard -->


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- Add a setting to enable or disable showing lyrics when the player artwork is tapped.
- Keep the setting enabled by default to preserve the existing behavior.
- Apply the setting to both portrait and landscape player layouts, including configurations where swipe-to-skip is enabled.
- Add English and Japanese strings for the new setting.
- Rename the gesture settings fragment to reflect that it now contains both swipe and tap-related options.

### Before/After Screenshots/Screen Record

- Before: Tapping the player artwork always shows the lyrics.
- After: The behavior can be disabled using the new "Tap artwork to show lyrics" setting.

### Fixes the following issue(s)

- Fixes #51

## Due diligence

- [ ] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)