### PR TITLE
feat: show the signed-in account's profile image

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/App.kt
+++ b/app/src/main/java/com/dd3boh/outertune/App.kt
@@ -26,6 +26,8 @@ import coil3.request.allowHardware
 import coil3.request.crossfade
 import com.dd3boh.outertune.constants.AccountChannelHandleKey
 import com.dd3boh.outertune.constants.AccountEmailKey
+import com.dd3boh.outertune.constants.AccountImageFetchedKey
+import com.dd3boh.outertune.constants.AccountImageUrlKey
 import com.dd3boh.outertune.constants.AccountNameKey
 import com.dd3boh.outertune.constants.ContentCountryKey
 import com.dd3boh.outertune.constants.ContentLanguageKey
@@ -46,6 +48,7 @@ import com.dd3boh.outertune.utils.CoilBitmapLoader
 import com.dd3boh.outertune.utils.LocalArtworkPathKeyer
 import com.dd3boh.outertune.utils.dataStore
 import com.dd3boh.outertune.utils.get
+import com.dd3boh.outertune.utils.normalizeDataSyncId
 import com.dd3boh.outertune.utils.reportException
 import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.models.YouTubeLocale
@@ -131,20 +134,7 @@ class App : Application(), SingletonImageLoader.Factory {
                 .map { it[DataSyncIdKey] }
                 .distinctUntilChanged()
                 .collect { dataSyncId ->
-                    YouTube.dataSyncId = dataSyncId?.let {
-                        /*
-                         * Workaround to avoid breaking older installations that have a dataSyncId
-                         * that contains "||" in it.
-                         * If the dataSyncId ends with "||" and contains only one id, then keep the
-                         * id before the "||".
-                         * If the dataSyncId contains "||" and is not at the end, then keep the
-                         * second id.
-                         * This is needed to keep using the same account as before.
-                         */
-                        it.takeIf { !it.contains("||") }
-                            ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
-                            ?: it.substringAfter("||")
-                    }
+                    YouTube.dataSyncId = normalizeDataSyncId(dataSyncId)
                 }
         }
         GlobalScope.launch {
@@ -219,6 +209,8 @@ class App : Application(), SingletonImageLoader.Factory {
                     settings.remove(AccountNameKey)
                     settings.remove(AccountEmailKey)
                     settings.remove(AccountChannelHandleKey)
+                    settings.remove(AccountImageUrlKey)
+                    settings.remove(AccountImageFetchedKey)
                 }
             }
         }

--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -100,6 +100,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.core.net.toUri
 import androidx.core.util.Consumer
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -185,6 +186,7 @@ import com.dd3boh.outertune.ui.theme.OuterTuneTheme
 import com.dd3boh.outertune.ui.utils.appBarScrollBehavior
 import com.dd3boh.outertune.utils.ActivityLauncherHelper
 import com.dd3boh.outertune.utils.NetworkConnectivityObserver
+import com.dd3boh.outertune.utils.AccountImageFetcher
 import com.dd3boh.outertune.utils.SyncUtils
 import com.dd3boh.outertune.utils.lmScannerCoroutine
 import com.dd3boh.outertune.utils.rememberEnumPreference
@@ -206,6 +208,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var syncUtils: SyncUtils
+
+    @Inject
+    lateinit var accountImageFetcher: AccountImageFetcher
 
     lateinit var activityLauncher: ActivityLauncherHelper
     lateinit var connectivityObserver: NetworkConnectivityObserver
@@ -247,6 +252,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(controllerViewModel)
+        lifecycleScope.launch { accountImageFetcher.fetchOnce() }
         controllerViewModel.addControllerCallback(lifecycle) { controller, _ ->
             playerConnection = PlayerConnection(controllerViewModel, database)
         }
@@ -441,6 +447,7 @@ class MainActivity : ComponentActivity() {
                         LocalDownloadUtil provides downloadUtil,
                         LocalShimmerTheme provides ShimmerTheme,
                         LocalSyncUtils provides syncUtils,
+                        LocalAccountImageFetcher provides accountImageFetcher,
                         LocalNetworkConnected provides isNetworkConnected,
                         LocalSnackbarHostState provides snackbarHostState,
                     ) {
@@ -1096,5 +1103,6 @@ val LocalPlayerConnection = staticCompositionLocalOf<PlayerConnection?> { error(
 val LocalPlayerAwareWindowInsets = compositionLocalOf<WindowInsets> { error("No player WindowInsets provided") }
 val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No DownloadUtil provided") }
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
+val LocalAccountImageFetcher = staticCompositionLocalOf<AccountImageFetcher> { error("No AccountImageFetcher provided") }
 val LocalNetworkConnected = staticCompositionLocalOf<Boolean> { error("No Network Status provided") }
 val LocalSnackbarHostState = staticCompositionLocalOf<SnackbarHostState> { error("No SnackbarHostState provided") }

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -203,6 +203,8 @@ val InnerTubeCookieKey = stringPreferencesKey("innerTubeCookie")
 val AccountNameKey = stringPreferencesKey("accountName")
 val AccountEmailKey = stringPreferencesKey("accountEmail")
 val AccountChannelHandleKey = stringPreferencesKey("accountChannelHandle")
+val AccountImageUrlKey = stringPreferencesKey("accountImageUrl")
+val AccountImageFetchedKey = booleanPreferencesKey("accountImageFetched")
 
 
 /**

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/AccountAvatar.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/AccountAvatar.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 OuterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
+package com.dd3boh.outertune.ui.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.dd3boh.outertune.constants.AccountImageUrlKey
+import com.dd3boh.outertune.constants.InnerTubeCookieKey
+import com.dd3boh.outertune.utils.rememberPreference
+import com.zionhuang.innertube.utils.parseCookieString
+
+/**
+ * The signed-in account's profile image, falling back to [placeholder] when signed out, when no
+ * image has been stored, or when the image cannot be loaded.
+ */
+@Composable
+fun AccountAvatar(
+    modifier: Modifier = Modifier,
+    size: Dp = 24.dp,
+    contentDescription: String? = null,
+    placeholder: @Composable () -> Unit,
+) {
+    val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
+    val imageUrl by rememberPreference(AccountImageUrlKey, "")
+    val isLoggedIn = remember(innerTubeCookie) {
+        runCatching { "SAPISID" in parseCookieString(innerTubeCookie) }.getOrDefault(false)
+    }
+
+    if (!isLoggedIn || imageUrl.isEmpty()) {
+        placeholder()
+        return
+    }
+
+    SubcomposeAsyncImage(
+        model = imageUrl,
+        contentDescription = contentDescription,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape),
+        loading = { placeholder() },
+        error = { placeholder() },
+    )
+}

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/LoginScreen.kt
@@ -2,7 +2,6 @@ package com.dd3boh.outertune.ui.screens
 
 import android.annotation.SuppressLint
 import android.webkit.CookieManager
-import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
@@ -18,29 +17,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.datastore.preferences.core.edit
 import androidx.navigation.NavController
+import com.dd3boh.outertune.LocalAccountImageFetcher
 import com.dd3boh.outertune.LocalPlayerAwareWindowInsets
 import com.dd3boh.outertune.R
-import com.dd3boh.outertune.constants.AccountChannelHandleKey
-import com.dd3boh.outertune.constants.AccountEmailKey
-import com.dd3boh.outertune.constants.AccountNameKey
+import com.dd3boh.outertune.constants.AccountImageFetchedKey
+import com.dd3boh.outertune.constants.AccountImageUrlKey
 import com.dd3boh.outertune.constants.DataSyncIdKey
 import com.dd3boh.outertune.constants.InnerTubeCookieKey
 import com.dd3boh.outertune.constants.TopBarInsets
 import com.dd3boh.outertune.constants.VisitorDataKey
 import com.dd3boh.outertune.ui.component.button.IconButton
 import com.dd3boh.outertune.ui.utils.backToMain
+import com.dd3boh.outertune.utils.dataStore
 import com.dd3boh.outertune.utils.rememberPreference
-import com.dd3boh.outertune.utils.reportException
 import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.utils.parseCookieString
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 @SuppressLint("SetJavaScriptEnabled")
 @OptIn(ExperimentalMaterial3Api::class, DelicateCoroutinesApi::class)
@@ -48,12 +51,8 @@ import kotlinx.coroutines.launch
 fun LoginScreen(
     navController: NavController,
 ) {
-    var visitorData by rememberPreference(VisitorDataKey, "")
-    var dataSyncId by rememberPreference(DataSyncIdKey, "")
-    var innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
-    var accountName by rememberPreference(AccountNameKey, "")
-    var accountEmail by rememberPreference(AccountEmailKey, "")
-    var accountChannelHandle by rememberPreference(AccountChannelHandleKey, "")
+    val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
+    val accountImageFetcher = LocalAccountImageFetcher.current
 
     // Once the cookie shows an established session, leave the login screen and return to the
     // start destination (the main screen) automatically.
@@ -77,30 +76,42 @@ fun LoginScreen(
                 webViewClient = object : WebViewClient() {
                     private var loginHandled = false
                     override fun onPageFinished(view: WebView, url: String?) {
-                        loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                        loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+                        // window.yt only exists on music.youtube.com, not on the sign-in pages.
+                        if (url?.startsWith("https://music.youtube.com") != true) return
+                        val cookie = CookieManager.getInstance().getCookie(url) ?: return
 
-                        if (url?.startsWith("https://music.youtube.com") == true) {
-                            val cookie = CookieManager.getInstance().getCookie(url)
-                            innerTubeCookie = cookie
+                        // Act only once the cookie shows an established session, so the fetch is not
+                        // started during intermediate, not-yet-signed-in page loads.
+                        if (loginHandled || "SAPISID" !in parseCookieString(cookie)) return
+                        loginHandled = true
 
-                            // Act only once the cookie shows an established session, so accountInfo()
-                            // is not called during intermediate, not-yet-signed-in page loads.
-                            if (!loginHandled && "SAPISID" in parseCookieString(cookie)) {
-                                loginHandled = true
-                                // Apply the cookie synchronously so accountInfo() is authenticated
-                                // without waiting for the asynchronous DataStore collector in App.
-                                YouTube.cookie = cookie
-                                GlobalScope.launch {
-                                    YouTube.accountInfo().onSuccess {
-                                        accountName = it.name
-                                        accountEmail = it.email.orEmpty()
-                                        accountChannelHandle = it.channelHandle.orEmpty()
-                                    }.onFailure {
-                                        reportException(it)
-                                    }
-                                }
+                        // Publish the cookie to the shared YouTube state immediately so that other
+                        // requests use the new session while the DataStore collector catches up.
+                        YouTube.cookie = cookie
+
+                        val visitorData = CompletableDeferred<String?>()
+                        val dataSyncId = CompletableDeferred<String?>()
+                        view.evaluateJavascript("window.yt.config_.VISITOR_DATA") {
+                            visitorData.complete(decodeEvaluatedString(it))
+                        }
+                        view.evaluateJavascript("window.yt.config_.DATASYNC_ID") {
+                            dataSyncId.complete(decodeEvaluatedString(it))
+                        }
+
+                        // Not tied to this screen: it closes as soon as the cookie is stored, which
+                        // would cancel a write and a fetch started from a screen-scoped coroutine.
+                        GlobalScope.launch {
+                            val newVisitorData = visitorData.await()
+                            val newDataSyncId = dataSyncId.await()?.substringBefore("||")
+                            context.dataStore.edit { settings ->
+                                settings[InnerTubeCookieKey] = cookie
+                                newVisitorData?.let { settings[VisitorDataKey] = it }
+                                newDataSyncId?.let { settings[DataSyncIdKey] = it }
+                                // The stored image belongs to the account being replaced.
+                                settings.remove(AccountImageUrlKey)
+                                settings.remove(AccountImageFetchedKey)
                             }
+                            accountImageFetcher.fetch()
                         }
                     }
                 }
@@ -109,20 +120,6 @@ fun LoginScreen(
                     setSupportZoom(true)
                     builtInZoomControls = true
                 }
-                addJavascriptInterface(object {
-                    @JavascriptInterface
-                    fun onRetrieveVisitorData(newVisitorData: String?) {
-                        if (newVisitorData != null) {
-                            visitorData = newVisitorData
-                        }
-                    }
-                    @JavascriptInterface
-                    fun onRetrieveDataSyncId(newDataSyncId: String?) {
-                        if (newDataSyncId != null) {
-                            dataSyncId = newDataSyncId.substringBefore("||")
-                        }
-                    }
-                }, "Android")
                 webView = this
                 loadUrl("https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fmusic.youtube.com")
             }
@@ -149,3 +146,13 @@ fun LoginScreen(
         webView?.goBack()
     }
 }
+
+/**
+ * Reads a value out of an [WebView.evaluateJavascript] result, which is JSON encoded: strings come
+ * back quoted and escaped, and an undefined value comes back as `null`.
+ */
+private fun decodeEvaluatedString(result: String?): String? =
+    result?.let { runCatching { Json.parseToJsonElement(it) }.getOrNull() }
+        ?.let { it as? JsonPrimitive }
+        ?.contentOrNull
+        ?.takeIf { it.isNotEmpty() }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -82,6 +82,7 @@ import com.dd3boh.outertune.constants.SearchSourceKey
 import com.dd3boh.outertune.constants.UpdateAvailableKey
 import com.dd3boh.outertune.db.entities.SearchHistory
 import com.dd3boh.outertune.extensions.tabMode
+import com.dd3boh.outertune.ui.component.AccountAvatar
 import com.dd3boh.outertune.ui.component.InputFieldHeight
 import com.dd3boh.outertune.ui.component.SearchBar
 import com.dd3boh.outertune.ui.component.SearchBarHorizontalPadding
@@ -443,10 +444,12 @@ private fun TopIconBar(
             )
         }
         IconButton(onClick = onAccountClick) {
-            Icon(
-                imageVector = Icons.Rounded.Person,
-                contentDescription = stringResource(R.string.account)
-            )
+            AccountAvatar(contentDescription = stringResource(R.string.account)) {
+                Icon(
+                    imageVector = Icons.Rounded.Person,
+                    contentDescription = stringResource(R.string.account)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.LastVersionKey
 import com.dd3boh.outertune.constants.TopBarInsets
 import com.dd3boh.outertune.constants.UpdateAvailableKey
+import com.dd3boh.outertune.ui.component.AccountAvatar
 import com.dd3boh.outertune.ui.component.ColumnWithContentPadding
 import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.button.IconButton
@@ -91,7 +92,7 @@ fun SettingsScreen(
         ) {
             PreferenceEntry(
                 title = { Text(stringResource(R.string.grp_account_sync)) },
-                icon = { Icon(Icons.Rounded.AccountCircle, null) },
+                icon = { AccountAvatar { Icon(Icons.Rounded.AccountCircle, null) } },
                 onClick = { navController.navigate("settings/account_sync") }
             )
         }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/AccountFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/AccountFrag.kt
@@ -29,38 +29,48 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.edit
 import androidx.navigation.NavController
 import com.dd3boh.outertune.App.Companion.forgetAccount
+import com.dd3boh.outertune.LocalAccountImageFetcher
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.AccountChannelHandleKey
 import com.dd3boh.outertune.constants.AccountEmailKey
+import com.dd3boh.outertune.constants.AccountImageFetchedKey
+import com.dd3boh.outertune.constants.AccountImageUrlKey
 import com.dd3boh.outertune.constants.AccountNameKey
 import com.dd3boh.outertune.constants.DataSyncIdKey
 import com.dd3boh.outertune.constants.InnerTubeCookieKey
 import com.dd3boh.outertune.constants.UseLoginForBrowse
 import com.dd3boh.outertune.constants.VisitorDataKey
+import com.dd3boh.outertune.ui.component.AccountAvatar
 import com.dd3boh.outertune.ui.component.PreferenceEntry
 import com.dd3boh.outertune.ui.component.SwitchPreference
 import com.dd3boh.outertune.ui.dialog.InfoLabel
 import com.dd3boh.outertune.ui.dialog.TextFieldDialog
+import com.dd3boh.outertune.utils.dataStore
 import com.dd3boh.outertune.utils.rememberPreference
 import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.utils.parseCookieString
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, DelicateCoroutinesApi::class)
 @Composable
 fun ColumnScope.AccountFrag(navController: NavController) {
     val context = LocalContext.current
 
-    val (accountName, onAccountNameChange) = rememberPreference(AccountNameKey, "")
-    val (accountEmail, onAccountEmailChange) = rememberPreference(AccountEmailKey, "")
-    val (accountChannelHandle, onAccountChannelHandleChange) = rememberPreference(AccountChannelHandleKey, "")
-    val (innerTubeCookie, onInnerTubeCookieChange) = rememberPreference(InnerTubeCookieKey, "")
-    val (visitorData, onVisitorDataChange) = rememberPreference(VisitorDataKey, "")
-    val (dataSyncId, onDataSyncIdChange) = rememberPreference(DataSyncIdKey, "")
+    val accountName by rememberPreference(AccountNameKey, "")
+    val accountEmail by rememberPreference(AccountEmailKey, "")
+    val accountChannelHandle by rememberPreference(AccountChannelHandleKey, "")
+    val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
+    val visitorData by rememberPreference(VisitorDataKey, "")
+    val dataSyncId by rememberPreference(DataSyncIdKey, "")
+    val accountImageFetcher = LocalAccountImageFetcher.current
     val isLoggedIn = remember(innerTubeCookie) {
         "SAPISID" in parseCookieString(innerTubeCookie)
     }
@@ -79,7 +89,7 @@ fun ColumnScope.AccountFrag(navController: NavController) {
             accountEmail.takeIf { it.isNotEmpty() }
                 ?: accountChannelHandle.takeIf { it.isNotEmpty() }
         } else null,
-        icon = { Icon(Icons.Rounded.Person, null) },
+        icon = { AccountAvatar { Icon(Icons.Rounded.Person, null) } },
         onClick = { navController.navigate("login") }
     )
     if (isLoggedIn) {
@@ -134,20 +144,20 @@ fun ColumnScope.AccountFrag(navController: NavController) {
             modifier = Modifier,
             initialTextFieldValue = TextFieldValue(text),
             onDone = { data ->
-                data.split("\n").forEach {
-                    if (it.startsWith("***INNERTUBE COOKIE*** =")) {
-                        onInnerTubeCookieChange(it.substringAfter("***INNERTUBE COOKIE*** ="))
-                    } else if (it.startsWith("***VISITOR DATA*** =")) {
-                        onVisitorDataChange(it.substringAfter("***VISITOR DATA*** ="))
-                    } else if (it.startsWith("***DATASYNC ID*** =")) {
-                        onDataSyncIdChange(it.substringAfter("***DATASYNC ID*** ="))
-                    } else if (it.startsWith("***ACCOUNT NAME*** =")) {
-                        onAccountNameChange(it.substringAfter("***ACCOUNT NAME*** ="))
-                    } else if (it.startsWith("***ACCOUNT EMAIL*** =")) {
-                        onAccountEmailChange(it.substringAfter("***ACCOUNT EMAIL*** ="))
-                    } else if (it.startsWith("***ACCOUNT CHANNEL HANDLE*** =")) {
-                        onAccountChannelHandleChange(it.substringAfter("***ACCOUNT CHANNEL HANDLE*** ="))
+                // Not tied to this screen, so that neither the write nor the fetch is cancelled
+                // when the dialog and the settings screen go away.
+                GlobalScope.launch {
+                    context.dataStore.edit { settings ->
+                        data.split("\n").forEach { line ->
+                            TOKEN_EDITOR_FIELDS.firstOrNull { line.startsWith(it.first) }?.let { (prefix, key) ->
+                                settings[key] = line.substringAfter(prefix)
+                            }
+                        }
+                        // The stored image belongs to the credentials being replaced.
+                        settings.remove(AccountImageUrlKey)
+                        settings.remove(AccountImageFetchedKey)
                     }
+                    accountImageFetcher.fetch()
                 }
             },
             onDismiss = { showTokenEditor = false },
@@ -168,6 +178,15 @@ fun ColumnScope.AccountFrag(navController: NavController) {
         )
     }
 }
+
+private val TOKEN_EDITOR_FIELDS = listOf(
+    "***INNERTUBE COOKIE*** =" to InnerTubeCookieKey,
+    "***VISITOR DATA*** =" to VisitorDataKey,
+    "***DATASYNC ID*** =" to DataSyncIdKey,
+    "***ACCOUNT NAME*** =" to AccountNameKey,
+    "***ACCOUNT EMAIL*** =" to AccountEmailKey,
+    "***ACCOUNT CHANNEL HANDLE*** =" to AccountChannelHandleKey,
+)
 
 @Composable
 fun ColumnScope.AccountExtrasFrag() {

--- a/app/src/main/java/com/dd3boh/outertune/utils/AccountCredentials.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/AccountCredentials.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 OuterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
+package com.dd3boh.outertune.utils
+
+import com.zionhuang.innertube.utils.parseCookieString
+
+/**
+ * Resolves a stored dataSyncId to the id the account is addressed by.
+ *
+ * Installations may hold a value containing "||": keep the id before it when the value ends with
+ * "||", and the id after it otherwise. Every request authenticating as an account must use the same
+ * resolution, or it addresses a different account than the rest of the app.
+ */
+fun normalizeDataSyncId(dataSyncId: String?): String? = dataSyncId?.let {
+    it.takeIf { !it.contains("||") }
+        ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
+        ?: it.substringAfter("||")
+}
+
+/**
+ * Whether a result fetched for [fetchedCookie] / [fetchedDataSyncId] still describes the account
+ * that is signed in now.
+ *
+ * The account can be replaced while a fetch is in flight, so the result is discarded unless the
+ * credentials it was fetched with are still the stored ones.
+ */
+fun isSameAccount(
+    fetchedCookie: String?,
+    fetchedDataSyncId: String?,
+    currentCookie: String?,
+    currentDataSyncId: String?,
+): Boolean {
+    if (currentCookie == null) return false
+    // A hand-edited cookie can be unparseable; treat it as not signed in rather than crashing.
+    val signedIn = runCatching { "SAPISID" in parseCookieString(currentCookie) }.getOrDefault(false)
+    if (!signedIn) return false
+    return fetchedCookie == currentCookie && fetchedDataSyncId == currentDataSyncId
+}

--- a/app/src/main/java/com/dd3boh/outertune/utils/AccountImageFetcher.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/AccountImageFetcher.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 OuterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
+package com.dd3boh.outertune.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import com.dd3boh.outertune.constants.AccountChannelHandleKey
+import com.dd3boh.outertune.constants.AccountEmailKey
+import com.dd3boh.outertune.constants.AccountImageFetchedKey
+import com.dd3boh.outertune.constants.AccountImageUrlKey
+import com.dd3boh.outertune.constants.AccountNameKey
+import com.dd3boh.outertune.constants.DataSyncIdKey
+import com.dd3boh.outertune.constants.InnerTubeCookieKey
+import com.dd3boh.outertune.constants.VisitorDataKey
+import com.zionhuang.innertube.YouTube
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches the signed-in account's details, including the profile image, and stores them.
+ */
+@Singleton
+class AccountImageFetcher @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val mutex = Mutex()
+    private val startupFetchStarted = AtomicBoolean(false)
+
+    /**
+     * Fetches for accounts that were already signed in when the app started, so that they get a
+     * profile image without signing in again. Runs at most once per process, and not at all once a
+     * successful response has been stored.
+     */
+    suspend fun fetchOnce() {
+        if (!startupFetchStarted.compareAndSet(false, true)) return
+        if (context.dataStore.data.first()[AccountImageFetchedKey] == true) return
+        fetch()
+    }
+
+    /**
+     * Fetches and stores the account details. Leaves everything untouched when the request or the
+     * parsing fails, so that the next start or sign-in retries.
+     */
+    suspend fun fetch() = mutex.withLock {
+        val preferences = context.dataStore.data.first()
+        val cookie = preferences[InnerTubeCookieKey]
+        val visitorData = preferences[VisitorDataKey]
+        val dataSyncId = normalizeDataSyncId(preferences[DataSyncIdKey])
+        if (!isSameAccount(cookie, dataSyncId, cookie, dataSyncId)) return@withLock
+
+        val accountInfo = YouTube.accountInfo(cookie, visitorData, dataSyncId).getOrElse {
+            reportException(it)
+            return@withLock
+        }
+
+        context.dataStore.edit { settings ->
+            // The account may have been replaced while the request was in flight. Comparing and
+            // writing inside one edit leaves no window for it to change in between.
+            if (!isSameAccount(cookie, dataSyncId, settings[InnerTubeCookieKey], normalizeDataSyncId(settings[DataSyncIdKey]))) {
+                return@edit
+            }
+            settings[AccountNameKey] = accountInfo.name
+            settings[AccountEmailKey] = accountInfo.email.orEmpty()
+            settings[AccountChannelHandleKey] = accountInfo.channelHandle.orEmpty()
+            settings[AccountImageFetchedKey] = true
+            val thumbnailUrl = accountInfo.thumbnailUrl
+            if (thumbnailUrl != null) {
+                settings[AccountImageUrlKey] = thumbnailUrl
+            } else {
+                settings.remove(AccountImageUrlKey)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/dd3boh/outertune/utils/AccountCredentialsTest.kt
+++ b/app/src/test/java/com/dd3boh/outertune/utils/AccountCredentialsTest.kt
@@ -1,0 +1,70 @@
+package com.dd3boh.outertune.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Boundaries of [normalizeDataSyncId] and [isSameAccount]: the two decisions that keep a fetched
+ * result attached to the account it was fetched for.
+ */
+class AccountCredentialsTest {
+
+    private val cookie = "SAPISID=abc; __Secure-3PAPISID=def"
+    private val otherCookie = "SAPISID=xyz; __Secure-3PAPISID=uvw"
+
+    @Test
+    fun normalize_keepsPlainId() {
+        assertEquals("id1", normalizeDataSyncId("id1"))
+    }
+
+    @Test
+    fun normalize_keepsIdBeforeTrailingSeparator() {
+        assertEquals("id1", normalizeDataSyncId("id1||"))
+    }
+
+    @Test
+    fun normalize_keepsIdAfterLeadingSeparator() {
+        assertEquals("id2", normalizeDataSyncId("id1||id2"))
+    }
+
+    @Test
+    fun normalize_passesNullThrough() {
+        assertNull(normalizeDataSyncId(null))
+    }
+
+    @Test
+    fun sameCredentials_stores() {
+        assertTrue(isSameAccount(cookie, "id1", cookie, "id1"))
+    }
+
+    @Test
+    fun changedCookie_doesNotStore() {
+        assertFalse(isSameAccount(cookie, "id1", otherCookie, "id1"))
+    }
+
+    @Test
+    fun changedDataSyncId_doesNotStore() {
+        assertFalse(isSameAccount(cookie, "id1", cookie, "id2"))
+    }
+
+    @Test
+    fun signedOut_doesNotStore() {
+        assertFalse(isSameAccount(cookie, "id1", null, null))
+        assertFalse(isSameAccount(null, null, null, null))
+    }
+
+    @Test
+    fun cookieWithoutSapisid_doesNotStore() {
+        val noSapisid = "__Secure-3PAPISID=def"
+        assertFalse(isSameAccount(noSapisid, "id1", noSapisid, "id1"))
+    }
+
+    @Test
+    fun unparseableCookie_doesNotStore() {
+        val malformed = "not-a-cookie"
+        assertFalse(isSameAccount(malformed, "id1", malformed, "id1"))
+    }
+}

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -34,10 +34,10 @@ class InnerTube {
     var dataSyncId: String? = null
     var cookie: String? = null
         set(value) {
+            // Validate before publishing so a parse failure cannot leave an invalid shared cookie.
+            if (value != null) parseCookieString(value)
             field = value
-            cookieMap = if (value == null) emptyMap() else parseCookieString(value)
         }
-    private var cookieMap = emptyMap<String, String>()
 
     var proxy: Proxy? = null
         set(value) {
@@ -76,7 +76,16 @@ class InnerTube {
         }
     }
 
-    private fun HttpRequestBuilder.ytClient(client: YouTubeClient, setLogin: Boolean = false) {
+    /**
+     * @param cookie overrides the shared [InnerTube.cookie] for this request only. Callers that must
+     * authenticate as a specific account, rather than as whichever account is currently configured,
+     * pass it explicitly.
+     */
+    private fun HttpRequestBuilder.ytClient(
+        client: YouTubeClient,
+        setLogin: Boolean = false,
+        cookie: String? = this@InnerTube.cookie,
+    ) {
         contentType(ContentType.Application.Json)
         headers {
             append("X-Goog-Api-Format-Version", "1")
@@ -86,6 +95,7 @@ class InnerTube {
             append("Referer", YouTubeClient.REFERER_YOUTUBE_MUSIC)
             if (setLogin && client.loginSupported) {
                 cookie?.let { cookie ->
+                    val cookieMap = parseCookieString(cookie)
                     append("cookie", cookie)
                     if ("SAPISID" !in cookieMap) return@let
                     val currentTime = System.currentTimeMillis() / 1000
@@ -249,8 +259,13 @@ class InnerTube {
 
     suspend fun getSwJsData() = httpClient.get("https://music.youtube.com/sw.js_data")
 
-    suspend fun accountMenu(client: YouTubeClient) = httpClient.post("account/account_menu") {
-        ytClient(client, setLogin = true)
+    suspend fun accountMenu(
+        client: YouTubeClient,
+        cookie: String?,
+        visitorData: String?,
+        dataSyncId: String?,
+    ) = httpClient.post("account/account_menu") {
+        ytClient(client, setLogin = true, cookie = cookie)
         setBody(AccountMenuBody(client.toContext(locale, visitorData, dataSyncId)))
     }
 

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -882,8 +882,16 @@ object YouTube {
             .jsonPrimitive.content
     }
 
-    suspend fun accountInfo(): Result<AccountInfo> = runCatching {
-        innerTube.accountMenu(WEB_REMIX).body<AccountMenuResponse>()
+    /**
+     * Fetches account information with an explicit cookie, visitor data and dataSyncId snapshot, so
+     * that the request is not affected by asynchronous updates to the shared credentials.
+     */
+    suspend fun accountInfo(
+        cookie: String?,
+        visitorData: String?,
+        dataSyncId: String?,
+    ): Result<AccountInfo> = runCatching {
+        innerTube.accountMenu(WEB_REMIX, cookie, visitorData, dataSyncId).body<AccountMenuResponse>()
             .actions[0].openPopupAction.popup.multiPageMenuRenderer
             .header?.activeAccountHeaderRenderer
             ?.toAccountInfo()

--- a/innertube/src/main/java/com/zionhuang/innertube/models/AccountInfo.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/AccountInfo.kt
@@ -4,4 +4,5 @@ data class AccountInfo(
     val name: String,
     val email: String?,
     val channelHandle: String?,
+    val thumbnailUrl: String? = null,
 )

--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/AccountMenuResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/AccountMenuResponse.kt
@@ -2,6 +2,7 @@ package com.zionhuang.innertube.models.response
 
 import com.zionhuang.innertube.models.AccountInfo
 import com.zionhuang.innertube.models.Runs
+import com.zionhuang.innertube.models.Thumbnail
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -33,11 +34,22 @@ data class AccountMenuResponse(
                             val accountName: Runs,
                             val email: Runs?,
                             val channelHandle: Runs?,
+                            val accountPhoto: AccountPhoto?,
                         ) {
                             fun toAccountInfo() = AccountInfo(
                                 name = accountName.runs!!.first().text,
                                 email = email?.runs?.first()?.text,
-                                channelHandle = channelHandle?.runs?.first()?.text
+                                channelHandle = channelHandle?.runs?.first()?.text,
+                                thumbnailUrl = accountPhoto?.thumbnails?.firstOrNull()?.url
+                            )
+
+                            /**
+                             * Holds the thumbnail list as nullable, unlike [com.zionhuang.innertube.models.Thumbnails],
+                             * so that a response carrying an accountPhoto without thumbnails still decodes.
+                             */
+                            @Serializable
+                            data class AccountPhoto(
+                                val thumbnails: List<Thumbnail>?,
                             )
                         }
                     }

--- a/innertube/src/test/java/com/zionhuang/innertube/AccountMenuResponseTest.kt
+++ b/innertube/src/test/java/com/zionhuang/innertube/AccountMenuResponseTest.kt
@@ -1,0 +1,58 @@
+package com.zionhuang.innertube
+
+import com.zionhuang.innertube.models.response.AccountMenuResponse
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Decoding of the account menu across the shapes the profile image comes in. A response without a
+ * usable image must still yield the rest of the account details.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class AccountMenuResponseTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private fun accountInfo(resource: String) =
+        javaClass.classLoader!!.getResourceAsStream(resource)!!.bufferedReader().use { it.readText() }
+            .let { json.decodeFromString<AccountMenuResponse>(it) }
+            .actions[0].openPopupAction.popup.multiPageMenuRenderer
+            .header!!.activeAccountHeaderRenderer
+            .toAccountInfo()
+
+    @Test
+    fun photoPresent_readsFirstThumbnail() {
+        val info = accountInfo("account_menu_full.json")
+        assertEquals("Test User", info.name)
+        assertEquals("test.user@example.com", info.email)
+        assertEquals("https://yt3.ggpht.com/example=s108-c-k-c0x00ffffff-no-rj", info.thumbnailUrl)
+    }
+
+    @Test
+    fun photoFieldMissing_hasNoUrl() {
+        val info = accountInfo("account_menu_no_photo_field.json")
+        assertEquals("Test User", info.name)
+        assertNull(info.thumbnailUrl)
+    }
+
+    @Test
+    fun photoNull_hasNoUrl() {
+        assertNull(accountInfo("account_menu_photo_null.json").thumbnailUrl)
+    }
+
+    @Test
+    fun thumbnailsKeyMissing_hasNoUrl() {
+        assertNull(accountInfo("account_menu_photo_no_thumbnails_key.json").thumbnailUrl)
+    }
+
+    @Test
+    fun thumbnailsEmpty_hasNoUrl() {
+        assertNull(accountInfo("account_menu_photo_empty_thumbnails.json").thumbnailUrl)
+    }
+}

--- a/innertube/src/test/resources/account_menu_full.json
+++ b/innertube/src/test/resources/account_menu_full.json
@@ -1,0 +1,89 @@
+{
+  "responseContext": {
+    "serviceTrackingParams": [
+      {
+        "service": "CSI",
+        "params": [
+          { "key": "c", "value": "WEB_REMIX" },
+          { "key": "cver", "value": "1.20250310.01.00" },
+          { "key": "yt_li", "value": "1" }
+        ]
+      },
+      {
+        "service": "GFEEDBACK",
+        "params": [{ "key": "logged_in", "value": "1" }]
+      }
+    ],
+    "responseId": "REDACTED"
+  },
+  "actions": [
+    {
+      "clickTrackingParams": "REDACTED",
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "header": {
+              "activeAccountHeaderRenderer": {
+                "accountName": { "runs": [{ "text": "Test User" }] },
+                "accountPhoto": {
+                  "thumbnails": [
+                    {
+                      "url": "https://yt3.ggpht.com/example=s108-c-k-c0x00ffffff-no-rj",
+                      "width": 108,
+                      "height": 108
+                    }
+                  ]
+                },
+                "settingsEndpoint": {
+                  "clickTrackingParams": "REDACTED",
+                  "applicationSettingsEndpoint": { "hack": true }
+                },
+                "email": { "runs": [{ "text": "test.user@example.com" }] },
+                "manageAccountTitle": {
+                  "runs": [
+                    {
+                      "text": "Google アカウントを管理",
+                      "navigationEndpoint": {
+                        "clickTrackingParams": "REDACTED",
+                        "urlEndpoint": {
+                          "url": "https://myaccount.google.com/",
+                          "target": "TARGET_NEW_WINDOW"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "trackingParams": "REDACTED"
+              }
+            },
+            "sections": [
+              {
+                "multiPageMenuSectionRenderer": {
+                  "items": [
+                    {
+                      "compactLinkRenderer": {
+                        "icon": { "iconType": "EXIT_TO_APP" },
+                        "title": { "runs": [{ "text": "ログアウト" }] },
+                        "navigationEndpoint": {
+                          "clickTrackingParams": "REDACTED",
+                          "signOutEndpoint": { "hack": true }
+                        },
+                        "trackingParams": "REDACTED"
+                      }
+                    }
+                  ],
+                  "trackingParams": "REDACTED"
+                }
+              }
+            ],
+            "trackingParams": "REDACTED",
+            "style": "MULTI_PAGE_MENU_STYLE_TYPE_ACCOUNT"
+          }
+        },
+        "popupType": "DROPDOWN",
+        "reusePopup": true
+      }
+    }
+  ],
+  "trackingParams": "REDACTED"
+}

--- a/innertube/src/test/resources/account_menu_no_photo_field.json
+++ b/innertube/src/test/resources/account_menu_no_photo_field.json
@@ -1,0 +1,20 @@
+{
+  "actions": [
+    {
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "header": {
+              "activeAccountHeaderRenderer": {
+                "accountName": { "runs": [{ "text": "Test User" }] },
+                "email": { "runs": [{ "text": "test.user@example.com" }] },
+                "trackingParams": "REDACTED"
+              }
+            },
+            "trackingParams": "REDACTED"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/innertube/src/test/resources/account_menu_photo_empty_thumbnails.json
+++ b/innertube/src/test/resources/account_menu_photo_empty_thumbnails.json
@@ -1,0 +1,21 @@
+{
+  "actions": [
+    {
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "header": {
+              "activeAccountHeaderRenderer": {
+                "accountName": { "runs": [{ "text": "Test User" }] },
+                "accountPhoto": { "thumbnails": [] },
+                "email": { "runs": [{ "text": "test.user@example.com" }] },
+                "trackingParams": "REDACTED"
+              }
+            },
+            "trackingParams": "REDACTED"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/innertube/src/test/resources/account_menu_photo_no_thumbnails_key.json
+++ b/innertube/src/test/resources/account_menu_photo_no_thumbnails_key.json
@@ -1,0 +1,21 @@
+{
+  "actions": [
+    {
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "header": {
+              "activeAccountHeaderRenderer": {
+                "accountName": { "runs": [{ "text": "Test User" }] },
+                "accountPhoto": {},
+                "email": { "runs": [{ "text": "test.user@example.com" }] },
+                "trackingParams": "REDACTED"
+              }
+            },
+            "trackingParams": "REDACTED"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/innertube/src/test/resources/account_menu_photo_null.json
+++ b/innertube/src/test/resources/account_menu_photo_null.json
@@ -1,0 +1,21 @@
+{
+  "actions": [
+    {
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "header": {
+              "activeAccountHeaderRenderer": {
+                "accountName": { "runs": [{ "text": "Test User" }] },
+                "accountPhoto": null,
+                "email": { "runs": [{ "text": "test.user@example.com" }] },
+                "trackingParams": "REDACTED"
+              }
+            },
+            "trackingParams": "REDACTED"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

The account entry only ever showed a generic person icon, even while signed in, so which account was
in use was not visible. It now shows the signed-in account's own profile image.

- Fetch the account details, including the profile image URL, right after signing in and once on the
  first start of a session that has no image stored yet
- Show the image wherever the account icon appears, and fall back to the icon when signed out, when
  no image is stored, or when the image cannot be loaded
- Clear the stored image before new credentials are published, so it cannot be shown for another
  account
- Authenticate the account request with an explicit cookie, visitor data and dataSyncId, so the
  request is not affected by asynchronous updates to the shared credentials
- Build a request's cookie header and authorization hash from the same parsed cookie

- Fixes #70 

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts.