### PR TITLE
feat: route the top bar account icon to account sync settings

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/search/SearchScreen.kt
@@ -366,7 +366,7 @@ fun SearchBarContainer(
             onStatsClick = { navController.navigate("stats") },
             onScannerClick = { navController.navigate("settings/local") },
             onSettingsClick = { navController.navigate("settings") },
-            onAccountClick = { navController.navigate("account") },
+            onAccountClick = { navController.navigate("settings/account_sync") },
             onSearchClick = { onSearchActiveChange(true) },
         )
     }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Tapping the account icon used to open a list of the signed-in account's YouTube Music playlists, albums and artists, so reaching login, logout and the sync settings took two taps. It now opens Account and sync directly.

The existing account screen is unchanged and still opens from the "Your YouTube playlists" heading on the Home screen. Since the icon row is shared by every enabled tab, the new destination applies on Home, Songs, Folders, Local and Library alike.

### Before/After Screenshots/Screen Record

- Before: tapping the account icon opened the account screen titled with the account name.
- After: tapping the account icon opens Account and sync.

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)
