### PR TITLE
perf: speed up home screen refresh

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -426,7 +426,7 @@ fun HomeScreen(
                             YouTubeCardItem(
                                 item = item,
                                 width = recentActivityItemWidth,
-                                isActive = when (item.type) {
+                                isActive = queuePlaylistId != null && when (item.type) {
                                     RecentActivityType.PLAYLIST -> queuePlaylistId == item.id
                                     RecentActivityType.ALBUM -> queuePlaylistId == item.playlistId
                                     RecentActivityType.ARTIST -> queuePlaylistId == item.radioPlaylistId ||

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -17,7 +17,6 @@ import com.dd3boh.outertune.utils.reportException
 import com.dd3boh.outertune.utils.syncCoroutine
 import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.models.PlaylistItem
-import com.zionhuang.innertube.models.WatchEndpoint
 import com.zionhuang.innertube.models.YTItem
 import com.zionhuang.innertube.pages.ExplorePage
 import com.zionhuang.innertube.pages.HomePage
@@ -26,6 +25,7 @@ import com.zionhuang.innertube.utils.parseCookieString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -62,96 +62,108 @@ class HomeViewModel @Inject constructor(
     val allLocalItems = MutableStateFlow<List<LocalItem>>(emptyList())
     val allYtItems = MutableStateFlow<List<YTItem>>(emptyList())
 
-    private suspend fun load(manual: Boolean) {
-        isLoading.value = true
+    private suspend fun load(manual: Boolean) =
+        try {
+            isLoading.value = true
 
-        quickPicks.value = database.quickPicks()
-            .first().shuffled().take(20)
+            quickPicks.value = database.quickPicks()
+                .first().shuffled().take(20)
 
-        forgottenFavorites.value = database.forgottenFavorites()
-            .first().shuffled().take(20)
+            forgottenFavorites.value = database.forgottenFavorites()
+                .first().shuffled().take(20)
 
-        val fromTimeStamp = System.currentTimeMillis() - 86400000 * 7 * 2
-        val keepListeningSongs = database.mostPlayedSongs(fromTimeStamp, limit = 15, offset = 5)
-            .first().shuffled().take(10)
-        val keepListeningAlbums = database.mostPlayedAlbums(fromTimeStamp, limit = 8, offset = 2)
-            .first().filter { it.album.thumbnailUrl != null }.shuffled().take(5)
-        val keepListeningArtists = database.mostPlayedArtists(0, 1)
-            .first().filter { it.artist.isYouTubeArtist && it.artist.thumbnailUrl != null }.shuffled().take(5)
-        keepListening.value = (keepListeningSongs + keepListeningAlbums + keepListeningArtists).shuffled()
+            val fromTimeStamp = System.currentTimeMillis() - 86400000 * 7 * 2
+            val keepListeningSongs = database.mostPlayedSongs(fromTimeStamp, limit = 15, offset = 5)
+                .first().shuffled().take(10)
+            val keepListeningAlbums = database.mostPlayedAlbums(fromTimeStamp, limit = 8, offset = 2)
+                .first().filter { it.album.thumbnailUrl != null }.shuffled().take(5)
+            val keepListeningArtists = database.mostPlayedArtists(0, 1)
+                .first().filter { it.artist.isYouTubeArtist && it.artist.thumbnailUrl != null }.shuffled().take(5)
+            keepListening.value = (keepListeningSongs + keepListeningAlbums + keepListeningArtists).shuffled()
 
-        allLocalItems.value =
-            (quickPicks.value.orEmpty() + forgottenFavorites.value.orEmpty() + keepListening.value.orEmpty())
-                .filter { it is Song || it is Album }
+            allLocalItems.value =
+                (quickPicks.value.orEmpty() + forgottenFavorites.value.orEmpty() + keepListening.value.orEmpty())
+                    .filter { it is Song || it is Album }
 
-        if (YouTube.cookie != null) { // if logged in
-            // InnerTune way is YouTube.likedPlaylists().onSuccess { ... }
-            // OuterTune uses YouTube.library("FEmusic_liked_playlists").completedL().onSuccess { ... }
-            YouTube.library("FEmusic_liked_playlists").completed().onSuccess {
-                accountPlaylists.value = it.items.filterIsInstance<PlaylistItem>()
-            }.onFailure {
-                reportException(it)
-            }
-        }
-
-        // Similar to artists
-        val artistRecommendations =
-            database.mostPlayedArtists(0, 1, limit = 10).first()
-                .filter { it.artist.isYouTubeArtist }
-                .shuffled().take(3)
-                .mapNotNull {
-                    val items = mutableListOf<YTItem>()
-                    YouTube.artist(it.id).onSuccess { page ->
-                        items += page.sections.getOrNull(page.sections.size - 2)?.items.orEmpty()
-                        items += page.sections.lastOrNull()?.items.orEmpty()
+            // The three groups below do not depend on each other, so they run at the same time.
+            coroutineScope {
+                launch {
+                    if (YouTube.cookie != null) {
+                        YouTube.library("FEmusic_liked_playlists").completed().onSuccess {
+                            accountPlaylists.value = it.items.filterIsInstance<PlaylistItem>()
+                        }.onFailure {
+                            reportException(it)
+                        }
                     }
-                    SimilarRecommendation(
-                        title = it,
-                        items = items
-                            .shuffled()
-                            .ifEmpty { return@mapNotNull null }
-                    )
+
+                    syncUtils.syncRecentActivity(manual)
                 }
-        // Similar to songs
-        val songRecommendations =
-            database.mostPlayedSongs(fromTimeStamp, limit = 10).first()
-                .filter { it.album != null }
-                .shuffled().take(2)
-                .mapNotNull { song ->
-                    val endpoint = YouTube.next(WatchEndpoint(videoId = song.id)).getOrNull()?.relatedEndpoint
-                        ?: return@mapNotNull null
-                    val page = YouTube.related(endpoint).getOrNull() ?: return@mapNotNull null
-                    SimilarRecommendation(
-                        title = song,
-                        items = (page.songs.shuffled().take(8) +
-                                page.albums.shuffled().take(4) +
-                                page.artists.shuffled().take(4) +
-                                page.playlists.shuffled().take(4))
-                            .shuffled()
-                            .ifEmpty { return@mapNotNull null }
-                    )
+
+                launch {
+                    // Similar to artists
+                    val artistRecommendations =
+                        database.mostPlayedArtists(0, 1, limit = 10).first()
+                            .filter { it.artist.isYouTubeArtist }
+                            .shuffled().take(2)
+                            .mapNotNull {
+                                val items = mutableListOf<YTItem>()
+                                YouTube.artist(it.id).onSuccess { page ->
+                                    items += page.sections.getOrNull(page.sections.size - 2)?.items.orEmpty()
+                                    items += page.sections.lastOrNull()?.items.orEmpty()
+                                }
+                                SimilarRecommendation(
+                                    title = it,
+                                    items = items
+                                        .shuffled()
+                                        .ifEmpty { return@mapNotNull null }
+                                )
+                            }
+                    // Similar to songs
+//                    val songCandidates = database.mostPlayedSongs(fromTimeStamp, limit = 10).first()
+//                        .filter { it.album != null }
+//                        .shuffled().take(2)
+//                    val songRecommendations =
+//                        songCandidates
+//                            .mapNotNull { song ->
+//                                val endpoint = YouTube.next(WatchEndpoint(videoId = song.id))
+//                                    .getOrNull()?.relatedEndpoint
+//                                if (endpoint == null) return@mapNotNull null
+//                                val page = YouTube.related(endpoint).getOrNull() ?: return@mapNotNull null
+//                                SimilarRecommendation(
+//                                    title = song,
+//                                    items = (page.songs.shuffled().take(8) +
+//                                            page.albums.shuffled().take(4) +
+//                                            page.artists.shuffled().take(4) +
+//                                            page.playlists.shuffled().take(4))
+//                                        .shuffled()
+//                                        .ifEmpty { return@mapNotNull null }
+//                                )
+//                            }
+//                    similarRecommendations.value =
+//                        (artistRecommendations + songRecommendations).shuffled()
+                    similarRecommendations.value = artistRecommendations.shuffled()
                 }
-        similarRecommendations.value = (artistRecommendations + songRecommendations).shuffled()
 
-        YouTube.home().onSuccess { page ->
-            homePage.value = page
-        }.onFailure {
-            reportException(it)
+                launch {
+                    YouTube.home().onSuccess { page ->
+                        homePage.value = page
+                    }.onFailure {
+                        reportException(it)
+                    }
+
+                    YouTube.explore().onSuccess { page ->
+                        explorePage.value = page
+                    }.onFailure {
+                        reportException(it)
+                    }
+                }
+            }
+
+            allYtItems.value = similarRecommendations.value?.flatMap { it.items }.orEmpty() +
+                    homePage.value?.sections?.flatMap { it.items }.orEmpty()
+        } finally {
+            isLoading.value = false
         }
-
-        YouTube.explore().onSuccess { page ->
-            explorePage.value = page
-        }.onFailure {
-            reportException(it)
-        }
-
-        syncUtils.syncRecentActivity(manual)
-
-        allYtItems.value = similarRecommendations.value?.flatMap { it.items }.orEmpty() +
-                homePage.value?.sections?.flatMap { it.items }.orEmpty()
-
-        isLoading.value = false
-    }
 
     private val _isLoadingMore = MutableStateFlow(false)
     fun loadMoreYouTubeItems(continuation: String?) {
@@ -195,14 +207,20 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * @param manual true when the user asked for the refresh, which makes the sync ignore the cooldown.
+     * Refreshes the home content.
+     *
+     * When [manual] is `true`, recent activity synchronization ignores the
+     * auto-sync setting and cooldown.
      */
     fun refresh(manual: Boolean = false) {
         if (isRefreshing.value) return
         viewModelScope.launch(syncCoroutine) {
             isRefreshing.value = true
-            load(manual)
-            isRefreshing.value = false
+            try {
+                load(manual)
+            } finally {
+                isRefreshing.value = false
+            }
         }
     }
 

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -16,7 +16,6 @@ import com.zionhuang.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedC
 import com.zionhuang.innertube.models.YTItem
 import com.zionhuang.innertube.models.YouTubeClient
 import com.zionhuang.innertube.models.YouTubeClient.Companion.IOS
-import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB
 import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import com.zionhuang.innertube.models.YouTubeLocale
 import com.zionhuang.innertube.models.getContinuation
@@ -610,20 +609,7 @@ object YouTube {
                 it.musicTwoRowItemRenderer?.let { renderer ->
                     LibraryPage.fromMusicTwoRowItemRenderer(renderer)
                 }
-            }.toMutableList()
-
-        /*
-         * We need to fetch the artist page when accessing the library because it allows to have
-         * a proper playEndpoint, which is needed to correctly report the playing indicator in
-         * the home page.
-         *
-         * Despite this, we need to use the old thumbnail because it's the proper format for a
-         * square picture, which is what we need.
-         */
-        items.forEachIndexed { index, item ->
-            if (item is ArtistItem)
-                items[index] = artist(item.id).getOrNull()?.artist!!.copy(thumbnail = item.thumbnail)
-        }
+            }
 
         LibraryPage(
             items = items,


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

The home screen refresh sent its requests to YouTube Music one after another, and the Recent activity sync added one artist page request per artist in the listing. The refresh indicator therefore stayed for several seconds, and stayed longer the more artists the listing held.

- Load the YouTube Music content in three concurrent groups instead of one sequence.
- Remove the per-artist page requests from the Recent activity sync. They only supplied a third playlist ID for the playing indicator, so the indicator now matches on the radio and shuffle IDs that the listing already returns.
- Reduce the artist-based "Similar to" sections from three to two, and stop building the song-based ones.
- Reset the loading flags in a finally block, so a failed refresh no longer leaves the pull-to-refresh indicator spinning and blocking later refreshes.

a manual refresh went from 10.4-10.8 s to 4.3-4.4 s

### Fixes the following issue(s)

- Fixes #76

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)