### PR TITLE
fix: fill missing artist thumbnails on sync

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
@@ -457,8 +457,17 @@ class SyncUtils @Inject constructor(
                                         bookmarkedAt = if (isLikedArtist) LocalDateTime.now() else null
                                     )
                                 )
-                            } else if (localArtist.artist.bookmarkedAt == null && isLikedArtist) {
-                                update(localArtist.artist.localToggleLike())
+                            } else {
+                                var updated = localArtist.artist
+                                if (updated.bookmarkedAt == null && isLikedArtist) {
+                                    updated = updated.localToggleLike()
+                                }
+                                if (updated.thumbnailUrl == null && remoteArtist.thumbnail != null) {
+                                    updated = updated.copy(thumbnailUrl = remoteArtist.thumbnail)
+                                }
+                                if (updated != localArtist.artist) {
+                                    update(updated)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Artists that have songs in the library showed no image in the library tab after
signing in and syncing. Only artists without any songs got one.

Saving songs and albums also creates the artist rows, and those rows carry no
thumbnail URL because song data does not include an artist image. Songs are
synced before artists, so those rows already exist by the time artist sync runs,
and artist sync only wrote a thumbnail URL when it inserted a new row.

Artist sync now fills the missing URL on existing rows as well, using the
thumbnail it already receives from the library listing. Rows that already have a
thumbnail are left untouched, and the subscription timestamp is still written
only under the previous condition.

Tested on a device: with the affected artists still showing no image, pulling to
refresh the library tab filled them in, while artists that already had an image
kept it and stayed subscribed.

### Before/After Screenshots/Screen Record

- Before:
- After:

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
