### PR TITLE
fix: prevent concurrent home load-more requests and stale results

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -168,16 +169,25 @@ class HomeViewModel @Inject constructor(
     private val _isLoadingMore = MutableStateFlow(false)
     fun loadMoreYouTubeItems(continuation: String?) {
         if (continuation == null) return
+        val requestedHomePage = homePage.value?.takeIf { it.continuation == continuation } ?: return
 
         viewModelScope.launch(Dispatchers.IO) {
             if (!_isLoadingMore.compareAndSet(false, true)) return@launch
 
             try {
+                if (homePage.value !== requestedHomePage) return@launch
+
                 val nextSections = YouTube.home(continuation).getOrNull() ?: return@launch
-                homePage.value = nextSections.copy(
-                    chips = homePage.value?.chips,
-                    sections = homePage.value?.sections.orEmpty() + nextSections.sections
-                )
+                homePage.update { currentHomePage ->
+                    if (currentHomePage !== requestedHomePage) {
+                        currentHomePage
+                    } else {
+                        nextSections.copy(
+                            chips = currentHomePage.chips,
+                            sections = currentHomePage.sections + nextSections.sections
+                        )
+                    }
+                }
             } finally {
                 _isLoadingMore.value = false
             }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -167,19 +167,20 @@ class HomeViewModel @Inject constructor(
 
     private val _isLoadingMore = MutableStateFlow(false)
     fun loadMoreYouTubeItems(continuation: String?) {
-        if (continuation == null || _isLoadingMore.value) return
+        if (continuation == null) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            _isLoadingMore.value = true
-            val nextSections = YouTube.home(continuation).getOrNull() ?: run {
+            if (!_isLoadingMore.compareAndSet(false, true)) return@launch
+
+            try {
+                val nextSections = YouTube.home(continuation).getOrNull() ?: return@launch
+                homePage.value = nextSections.copy(
+                    chips = homePage.value?.chips,
+                    sections = homePage.value?.sections.orEmpty() + nextSections.sections
+                )
+            } finally {
                 _isLoadingMore.value = false
-                return@launch
             }
-            homePage.value = nextSections.copy(
-                chips = homePage.value?.chips,
-                sections = homePage.value?.sections.orEmpty() + nextSections.sections
-            )
-            _isLoadingMore.value = false
         }
     }
 


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

The home screen could start multiple load-more requests before recognizing that one was already in progress.

A request started for one home page could also finish after a refresh or category change and append its sections to the page currently being displayed.

- Allow only the first simultaneous load-more request to start network communication.
- Always clear the loading state when the request finishes, fails, or is cancelled.
- Record the displayed home page when loading starts and append the returned sections only if that page is still displayed.

This preserves sequential loading of additional home sections while preventing duplicate requests and preventing sections from different home pages from being combined.

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE.

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)