### PR TITLE
fix: prevent crash when clearing the final queue

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -979,13 +979,14 @@ class MusicService : MediaLibraryService(),
      * because onMediaItemTransition runs before currentMediaMetadata is updated in onEvents.
      */
     private fun updateLyricsFetchTargets() {
+        val mediaItemCount = player.mediaItemCount
         val currentIndex = player.currentMediaItemIndex
-        if (currentIndex == C.INDEX_UNSET) {
+        if (currentIndex !in 0 until mediaItemCount) {
             lyricsFetchTargets.value = LyricsFetchTargets(null, emptyList())
             return
         }
         val current = player.getMediaItemAt(currentIndex).metadata
-        val upcoming = ((currentIndex + 1) until player.mediaItemCount)
+        val upcoming = ((currentIndex + 1) until mediaItemCount)
             .mapNotNull { player.getMediaItemAt(it).metadata }
         lyricsFetchTargets.value = LyricsFetchTargets(current, upcoming)
     }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Clearing the song queue until the player timeline is empty can crash the app.
The lyrics target update treated ExoPlayer's prospective media item index as an existing item and tried to read a nonexistent window.

**Changes:**

- Validate the current index against the media item count before reading the current and upcoming items.
- Clear the lyrics fetch targets when no valid item exists.

**Verification:**

"coreDebug" was built and installed successfully.
Clearing the queue after starting random playback no longer crashes the app.

### Fixes the following issue(s)

- Fixes #80

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)