### PR TITLE
Fix: Send client headers in stream requests

### DIFF
--- a/app/src/main/java/io/github/yuuichi_s/astertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/playback/DownloadUtil.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2026 AsterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
 package io.github.yuuichi_s.astertune.playback
 
 import android.content.Context
@@ -19,6 +26,9 @@ import androidx.media3.exoplayer.offline.DownloadNotificationHelper
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
+import com.zionhuang.innertube.YouTube
+import com.zionhuang.innertube.models.SongItem
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.yuuichi_s.astertune.R
 import io.github.yuuichi_s.astertune.constants.AudioQuality
 import io.github.yuuichi_s.astertune.constants.AudioQualityKey
@@ -47,9 +57,6 @@ import io.github.yuuichi_s.astertune.utils.reportException
 import io.github.yuuichi_s.astertune.utils.scanners.InvalidAudioFileException
 import io.github.yuuichi_s.astertune.utils.scanners.fileFromUri
 import io.github.yuuichi_s.astertune.utils.scanners.uriListFromString
-import com.zionhuang.innertube.YouTube
-import com.zionhuang.innertube.models.SongItem
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -84,7 +91,7 @@ class DownloadUtil @Inject constructor(
 
     private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
     private val audioQuality by enumPreference(context, AudioQualityKey, AudioQuality.AUTO)
-    private val songUrlCache = HashMap<String, Pair<String, Long>>()
+    private val songUrlCache = StreamUrlCache()
     private val dataSourceFactory = ResolvingDataSource.Factory(
         CacheDataSource.Factory()
             .setCache(playerCache)
@@ -102,8 +109,8 @@ class DownloadUtil @Inject constructor(
             return@Factory dataSpec
         }
 
-        songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {
-            return@Factory dataSpec.withUri(it.first.toUri())
+        songUrlCache[mediaId]?.let { cachedStream ->
+            return@Factory dataSpec.withResolvedStream(cachedStream)
         }
 
         val playbackData = runBlocking(Dispatchers.IO) {
@@ -136,8 +143,14 @@ class DownloadUtil @Inject constructor(
             "${it}&range=0-${format.contentLength ?: 10000000}"
         }
 
-        songUrlCache[mediaId] = streamUrl to System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
-        dataSpec.withUri(streamUrl.toUri())
+        val stream = songUrlCache.put(
+            mediaId = mediaId,
+            url = streamUrl,
+            requestHeaders = playbackData.streamHeaders,
+            clientName = playbackData.streamClient,
+            expiresInSeconds = playbackData.streamExpiresInSeconds,
+        )
+        dataSpec.withResolvedStream(stream)
     }
     val downloadNotificationHelper = DownloadNotificationHelper(context, ExoDownloadService.CHANNEL_ID)
     val downloadManager: DownloadManager =

--- a/app/src/main/java/io/github/yuuichi_s/astertune/playback/MusicService.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/playback/MusicService.kt
@@ -254,18 +254,8 @@ class MusicService : MediaLibraryService(),
     )
 
     private val lyricsFetchTargets = MutableStateFlow(LyricsFetchTargets(null, emptyList()))
-    /**
-     * Resolved stream urls by media id, with the time they claim to stay valid until. Hoisted out of
-     * [createDataSourceFactory] so a url googlevideo refuses mid-song can be dropped and resolved
-     * again, which is the only way past a url that validates and then dies a minute in.
-     */
-    private val songUrlCache = HashMap<String, Pair<String, Long>>()
-
-    /** Client each cached url came from, so a refused one can be skipped on the next resolution. */
-    private val songUrlClient = HashMap<String, String>()
-
-    /** Headers each cached url has to be fetched with, kept alongside it for the cache-hit path. */
-    private val songUrlHeaders = HashMap<String, Map<String, String>>()
+    // Shared by data source callbacks and playback error recovery.
+    private val songUrlCache = StreamUrlCache()
 
     /** Refresh attempts per media id, so a song that cannot play at all stops retrying. */
     private val streamRefreshes = HashMap<String, Int>()
@@ -780,18 +770,15 @@ class MusicService : MediaLibraryService(),
                 return@Factory dataSpec
             }
 
-            songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {
+            songUrlCache[mediaId]?.let { cachedStream ->
                 if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: remote song (temp cache)")
                 offloadScope.launch { recoverSong(mediaId) }
                 // Bounded like the fresh-resolve path below; letting this read run open-ended was
                 // measurably worse (playback died at 31 s rather than 62 s). The headers matter as
                 // much as the url: googlevideo expects the fetch to look like the client it issued
                 // the url for, and every read past the first chunk comes through here.
-                return@Factory dataSpec.withUri(it.first.toUri())
+                return@Factory dataSpec.withResolvedStream(cachedStream)
                     .subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
-                    .withRequestHeaders(
-                        dataSpec.httpRequestHeaders + songUrlHeaders[mediaId].orEmpty()
-                    )
             }
 
             if (SERVICE_DEBUG) Log.d(TAG, "PLAYING: remote song (online fetch)")
@@ -849,15 +836,15 @@ class MusicService : MediaLibraryService(),
             }
             offloadScope.launch { recoverSong(mediaId, playbackData) }
 
-            val streamUrl = playbackData.streamUrl
-
-            songUrlCache[mediaId] =
-                streamUrl to System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
-            songUrlClient[mediaId] = playbackData.streamClient
-            songUrlHeaders[mediaId] = playbackData.streamHeaders
-            dataSpec.withUri(streamUrl.toUri())
+            val stream = songUrlCache.put(
+                mediaId = mediaId,
+                url = playbackData.streamUrl,
+                requestHeaders = playbackData.streamHeaders,
+                clientName = playbackData.streamClient,
+                expiresInSeconds = playbackData.streamExpiresInSeconds,
+            )
+            dataSpec.withResolvedStream(stream)
                 .subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
-                .withRequestHeaders(dataSpec.httpRequestHeaders + playbackData.streamHeaders)
         }
     }
 
@@ -997,8 +984,8 @@ class MusicService : MediaLibraryService(),
     }
 
     /**
-     * Drops the refused stream url for [mediaId] and re-prepares so it resolves again, skipping the
-     * client that just failed.
+     * Drops the refused stream URL for [mediaId] and re-prepares so it resolves again. If the most
+     * recent URL came from WEB_REMIX, that client is temporarily excluded from the candidates.
      *
      * @return true if a retry was started, false once the song has used up its attempts
      */
@@ -1010,13 +997,11 @@ class MusicService : MediaLibraryService(),
         }
         streamRefreshes[mediaId] = attempts + 1
 
-        val failedClient = songUrlClient.remove(mediaId)
-        songUrlHeaders.remove(mediaId)
-        songUrlCache.remove(mediaId)
-        if (failedClient == "WEB_REMIX") {
+        val failedStream = songUrlCache.invalidate(mediaId)
+        if (failedStream?.clientName == "WEB_REMIX") {
             YTPlayerUtils.markWebRemixFailed(mediaId)
         }
-        Log.w(TAG, "stream for $mediaId refused on $failedClient, resolving again")
+        Log.w(TAG, "stream for $mediaId refused on ${failedStream?.clientName}, resolving again")
 
         player.prepare()
         return true
@@ -1059,9 +1044,7 @@ class MusicService : MediaLibraryService(),
             return
         }
 
-        // googlevideo hands out urls that pass validation and are then refused partway through the
-        // track, so the player is the first thing that learns a client's url is no good. Report it
-        // back and resolve again against a different client rather than dropping the song.
+        // A stream URL may still be rejected partway through a track after validation succeeds.
         val responseCode = (error.cause as? InvalidResponseCodeException)?.responseCode
         val mediaId = player.currentMediaItem?.mediaId
         if ((responseCode == 403 || responseCode == 410) && mediaId != null &&

--- a/app/src/main/java/io/github/yuuichi_s/astertune/playback/StreamUrlCache.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/playback/StreamUrlCache.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 AsterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+package io.github.yuuichi_s.astertune.playback
+
+import androidx.core.net.toUri
+import androidx.media3.datasource.DataSpec
+
+/**
+ * Resolved stream data cached and retrieved as a single value.
+ *
+ * The URL, expiry time, issuing client, and request headers belong to the same resolution.
+ */
+internal data class CachedStreamUrl(
+    val url: String,
+    val expiresAtMillis: Long,
+    val clientName: String,
+    val requestHeaders: Map<String, String>,
+)
+
+/**
+ * Thread-safe cache for resolved streams shared by data source callbacks.
+ *
+ * Cache bookkeeping is synchronized; callers perform network and player operations outside the
+ * lock. Lookups remove expired entries so callers cannot reuse stale request data.
+ */
+internal class StreamUrlCache(
+    private val currentTimeMillis: () -> Long = System::currentTimeMillis,
+) {
+    private val lock = Any()
+    private val entries = HashMap<String, CachedStreamUrl>()
+
+    operator fun get(mediaId: String): CachedStreamUrl? = synchronized(lock) {
+        val stream = entries[mediaId] ?: return@synchronized null
+        if (stream.expiresAtMillis <= currentTimeMillis()) {
+            entries.remove(mediaId)
+            null
+        } else {
+            stream
+        }
+    }
+
+    fun put(
+        mediaId: String,
+        url: String,
+        requestHeaders: Map<String, String>,
+        clientName: String,
+        expiresInSeconds: Int,
+    ): CachedStreamUrl = synchronized(lock) {
+        CachedStreamUrl(
+            url = url,
+            expiresAtMillis = currentTimeMillis() + expiresInSeconds * 1000L,
+            clientName = clientName,
+            requestHeaders = requestHeaders.toMap(),
+        ).also { entries[mediaId] = it }
+    }
+
+    /**
+     * Removes and returns the cached value without checking expiry so a failed request can be
+     * attributed to the client that issued it.
+     */
+    fun invalidate(mediaId: String): CachedStreamUrl? = synchronized(lock) {
+        entries.remove(mediaId)
+    }
+}
+
+internal fun resolvedRequestHeaders(
+    existingHeaders: Map<String, String>,
+    stream: CachedStreamUrl,
+): Map<String, String> = existingHeaders + stream.requestHeaders
+
+internal fun DataSpec.withResolvedStream(stream: CachedStreamUrl): DataSpec =
+    withUri(stream.url.toUri())
+        .withRequestHeaders(resolvedRequestHeaders(httpRequestHeaders, stream))

--- a/app/src/main/java/io/github/yuuichi_s/astertune/utils/YTPlayerUtils.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/utils/YTPlayerUtils.kt
@@ -24,7 +24,6 @@ import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.models.YouTubeClient
 import com.zionhuang.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_43_32
 import com.zionhuang.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_65_10
-import com.zionhuang.innertube.models.YouTubeClient.Companion.ANDROID_VR_NO_AUTH
 import com.zionhuang.innertube.models.YouTubeClient.Companion.IOS
 import com.zionhuang.innertube.models.YouTubeClient.Companion.ORIGIN_YOUTUBE_MUSIC
 import com.zionhuang.innertube.models.YouTubeClient.Companion.REFERER_YOUTUBE_MUSIC
@@ -109,13 +108,13 @@ object YTPlayerUtils {
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
         /** Client that produced [streamUrl], so the player can report it back if the url is refused. */
-        val streamClient: String = "unknown",
+        val streamClient: String,
         /**
          * Headers the media request has to carry. googlevideo issues a url on behalf of a specific
          * client and expects the fetch to look like it came from that client; a request with the
          * http library's own defaults is served briefly and then refused.
          */
-        val streamHeaders: Map<String, String> = emptyMap(),
+        val streamHeaders: Map<String, String>,
     )
 
     /** Identifies a media request as coming from the client the stream url was issued for. */
@@ -196,6 +195,7 @@ object YTPlayerUtils {
             streamUrl = null
             streamExpiresInSeconds = null
             streamClient = null
+            streamHeaders = emptyMap()
 
             Log.d(TAG, "Trying stream client ${clientIndex + 1}/${STREAM_CLIENTS.size}: ${client.clientName}")
 
@@ -288,13 +288,14 @@ object YTPlayerUtils {
         Log.d(TAG, "[$videoId] stream url: $streamUrl")
 
         PlaybackData(
-            audioConfig,
-            videoDetails,
-            playbackTracking,
-            format,
-            streamUrl,
-            streamExpiresInSeconds,
-            streamClient ?: MAIN_CLIENT.clientName,
+            audioConfig = audioConfig,
+            videoDetails = videoDetails,
+            playbackTracking = playbackTracking,
+            format = format,
+            streamUrl = streamUrl,
+            streamExpiresInSeconds = streamExpiresInSeconds,
+            streamClient = streamClient ?: MAIN_CLIENT.clientName,
+            streamHeaders = streamHeaders,
         )
     }
 
@@ -336,13 +337,14 @@ object YTPlayerUtils {
      * If this returns true the url is likely to work.
      * If this returns false the url might cause an error during playback.
      */
-    private fun validateStatus(url: String, headers: Map<String, String> = emptyMap()): Boolean {
+    private fun validateStatus(url: String, headers: Map<String, String>): Boolean {
         try {
             // googlevideo often rejects HEAD with 403 even when the stream plays; validate with a
             // tiny ranged GET instead, which is how the player actually fetches the media.
             val requestBuilder = okhttp3.Request.Builder()
                 .header("Range", "bytes=0-0")
                 .url(url)
+            headers.forEach { (name, value) -> requestBuilder.header(name, value) }
             val response = httpClient.newCall(requestBuilder.build()).execute()
             val ok = response.isSuccessful
             if (!ok) {

--- a/app/src/test/java/io/github/yuuichi_s/astertune/playback/StreamUrlCacheTest.kt
+++ b/app/src/test/java/io/github/yuuichi_s/astertune/playback/StreamUrlCacheTest.kt
@@ -1,0 +1,99 @@
+package io.github.yuuichi_s.astertune.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StreamUrlCacheTest {
+    @Test
+    fun getReturnsTheCachedStreamBeforeExpiry() {
+        var now = 1_000L
+        val cache = StreamUrlCache { now }
+
+        val inserted = cache.put(
+            mediaId = "song",
+            url = "https://example.com/stream",
+            requestHeaders = mapOf("User-Agent" to "client"),
+            clientName = "VISIONOS",
+            expiresInSeconds = 60,
+        )
+        now += 59_999L
+
+        assertEquals(inserted, cache["song"])
+    }
+
+    @Test
+    fun getRemovesTheCachedStreamAtTheExpiryBoundary() {
+        var now = 1_000L
+        val cache = StreamUrlCache { now }
+        cache.put("song", "https://example.com/stream", emptyMap(), "VISIONOS", 60)
+
+        now += 60_000L
+
+        assertNull(cache["song"])
+        assertNull(cache.invalidate("song"))
+    }
+
+    @Test
+    fun invalidateReturnsAndRemovesTheCachedStream() {
+        val cache = StreamUrlCache { 1_000L }
+        val inserted = cache.put(
+            mediaId = "song",
+            url = "https://example.com/stream",
+            requestHeaders = mapOf("User-Agent" to "client"),
+            clientName = "VISIONOS",
+            expiresInSeconds = 60,
+        )
+
+        assertEquals(inserted, cache.invalidate("song"))
+        assertNull(cache["song"])
+    }
+
+    @Test
+    fun putCopiesTheRequestHeaders() {
+        val cache = StreamUrlCache { 1_000L }
+        val headers = mutableMapOf("User-Agent" to "client")
+        cache.put(
+            mediaId = "song",
+            url = "https://example.com/stream",
+            requestHeaders = headers,
+            clientName = "VISIONOS",
+            expiresInSeconds = 60,
+        )
+
+        headers["User-Agent"] = "changed"
+
+        assertEquals("client", cache["song"]?.requestHeaders?.get("User-Agent"))
+    }
+
+    @Test
+    fun resolvedHeadersPreferTheStreamHeaders() {
+        val stream = cachedStream(mapOf("User-Agent" to "stream", "Origin" to "stream-origin"))
+
+        val headers = resolvedRequestHeaders(
+            existingHeaders = mapOf("User-Agent" to "existing"),
+            stream = stream,
+        )
+
+        assertEquals("stream", headers["User-Agent"])
+        assertEquals("stream-origin", headers["Origin"])
+    }
+
+    @Test
+    fun resolvedHeadersRetainExistingHeaders() {
+        val headers = resolvedRequestHeaders(
+            existingHeaders = mapOf("Range" to "bytes=0-100"),
+            stream = cachedStream(mapOf("User-Agent" to "stream")),
+        )
+
+        assertEquals("bytes=0-100", headers["Range"])
+        assertEquals("stream", headers["User-Agent"])
+    }
+
+    private fun cachedStream(headers: Map<String, String>) = CachedStreamUrl(
+        url = "https://example.com/stream",
+        expiresAtMillis = 61_000L,
+        clientName = "VISIONOS",
+        requestHeaders = headers,
+    )
+}


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Stream resolution generates request headers for the client to which the stream URL is issued, but performs no further processing. URL validation, playback, and downloads are all handled based on the HTTP client’s own default settings. Since googlevideo issues URLs on behalf of specific clients, it may reject requests that are not recognized as coming from those clients.

- Return the headers generated by stream resolution and send them attached to validation requests, all playback requests, and all download requests.
- Store the resolved URL as a single cache entry along with its expiration time, the issuing client, and the headers. Since stream resolution occurs on the load thread while mid-track error recovery occurs on the application thread, the cache is synchronized. This replaces three simple maps that were previously updated separately from both sides.
- Fixed the KDoc regarding retries during track playback. Previously, it stated that the client that failed most recently would be “skipped” during the next resolution, but in reality, only WEB_REMIX is excluded.
- Added unit tests covering cache expiration boundaries, invalidation, header copying, and header prioritization.

### Verification

- `./gradlew testFullDebugUnitTest --tests '*StreamUrlCacheTest*'` passes (6 tests, no failures).
- Playback and download on a device: Xperia 1 VII

### Fixes the following issue(s)

- N/A

### Relies on the following changes

- N/A

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md)