### PR TITLE
fix: Validation and Caching of Player Encryption Settings from Remote…

### DIFF
--- a/app/src/main/java/io/github/yuuichi_s/astertune/utils/cipher/PlayerCipherConfig.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/utils/cipher/PlayerCipherConfig.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okio.BufferedSource
 import org.json.JSONObject
 import java.io.File
 
@@ -61,8 +62,11 @@ object PlayerCipherConfigStore {
     /** Only this schema is understood; anything else is ignored so a future format cannot corrupt the map. */
     private const val SCHEMA_VERSION = 1
 
-    /** Sanity cap on the downloaded file; the real one is tens of KB. */
-    private const val MAX_CONFIG_CHARS = 4 * 1024 * 1024
+    /** Sanity cap on how much of the response body is read into memory; the real file is tens of KB. */
+    private const val MAX_CONFIG_BYTES = 4L * 1024 * 1024
+
+    // sigFuncName and nClass are embedded directly in JavaScript source, so their character sets are restricted.
+    private val JS_IDENTIFIER = Regex("^[A-Za-z_$][A-Za-z0-9_$]*$")
 
     /**
      * Minimum time between network attempts. A player that stays unknown (upstream has not published
@@ -189,14 +193,14 @@ object PlayerCipherConfigStore {
                 Log.e(TAG, "Config fetch failed: HTTP ${response.code}")
                 null
             } else {
-                val text = response.body?.string()
+                val body = response.body
                 when {
-                    text == null -> null
-                    text.length > MAX_CONFIG_CHARS -> {
-                        Log.e(TAG, "Config fetch rejected: ${text.length} chars")
+                    body == null -> null
+                    exceedsLimit(body.source(), MAX_CONFIG_BYTES) -> {
+                        Log.e(TAG, "Config fetch rejected: over $MAX_CONFIG_BYTES bytes")
                         null
                     }
-                    else -> text
+                    else -> body.string()
                 }
             }
         }
@@ -227,20 +231,29 @@ object PlayerCipherConfigStore {
         return result
     }
 
+    private fun parseEntry(entry: JSONObject): PlayerCipherConfig? =
+        parseConfig(entry.optString("sig"), entry.optString("nClass"))
+
     // sig is a `name(int,int,INPUT)` call; returns null on any malformed field so one bad entry can't break the map.
-    private fun parseEntry(entry: JSONObject): PlayerCipherConfig? {
-        val sig = entry.optString("sig")
-        val nClass = entry.optString("nClass")
-        if (sig.isEmpty() || nClass.isEmpty()) return null
+    internal fun parseConfig(sig: String, nClass: String): PlayerCipherConfig? {
+        if (sig.isEmpty() || !JS_IDENTIFIER.matches(nClass)) return null
 
         val open = sig.indexOf('(')
         if (open <= 0 || !sig.endsWith(")")) return null
         val funcName = sig.substring(0, open)
+        if (!JS_IDENTIFIER.matches(funcName)) return null
+
         val args = sig.substring(open + 1, sig.length - 1).split(",").map { it.trim() }
         if (args.lastOrNull() != "INPUT") return null
         val constants = args.dropLast(1).map { it.toIntOrNull() ?: return null }
         if (constants.isEmpty()) return null
 
         return PlayerCipherConfig(funcName, constants, nClass)
+    }
+
+    /** True when [source] holds more than [maxBytes], without reading the whole body. */
+    internal fun exceedsLimit(source: BufferedSource, maxBytes: Long): Boolean {
+        source.request(maxBytes + 1)
+        return source.buffer.size > maxBytes
     }
 }

--- a/app/src/test/java/io/github/yuuichi_s/astertune/utils/cipher/PlayerCipherConfigTest.kt
+++ b/app/src/test/java/io/github/yuuichi_s/astertune/utils/cipher/PlayerCipherConfigTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 AsterTune Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
+package io.github.yuuichi_s.astertune.utils.cipher
+
+import okio.Buffer
+import okio.Source
+import okio.Timeout
+import okio.buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests validation of externally supplied cipher config fields and bounded response-body reads.
+ *
+ * The JVM tests exercise Android-independent helpers directly because `JSONObject` is an Android
+ * stub in local unit tests. The counting source verifies that an oversized response is rejected
+ * without consuming the complete body.
+ */
+class PlayerCipherConfigTest {
+
+    @Test
+    fun `accepts a well formed entry`() {
+        val config = PlayerCipherConfigStore.parseConfig("Tl(48,5831,INPUT)", "W_")
+        assertEquals(PlayerCipherConfig("Tl", listOf(48, 5831), "W_"), config)
+    }
+
+    @Test
+    fun `rejects a sig function name carrying a separator`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("evil;Tl(48,5831,INPUT)", "W_"))
+    }
+
+    @Test
+    fun `rejects a sig function name carrying a newline`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl\nevil(48,5831,INPUT)", "W_"))
+    }
+
+    @Test
+    fun `rejects an nClass carrying a separator`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(48,5831,INPUT)", "Yx('x',true); g.Yx"))
+    }
+
+    @Test
+    fun `rejects an nClass carrying a newline`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(48,5831,INPUT)", "W_\nevil"))
+    }
+
+    @Test
+    fun `rejects an empty nClass`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(48,5831,INPUT)", ""))
+    }
+
+    @Test
+    fun `rejects a non integer constant`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(a,5831,INPUT)", "W_"))
+    }
+
+    @Test
+    fun `rejects a call not ending in INPUT`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(48,5831)", "W_"))
+    }
+
+    @Test
+    fun `rejects a call without constants`() {
+        assertNull(PlayerCipherConfigStore.parseConfig("Tl(INPUT)", "W_"))
+    }
+
+    @Test
+    fun `accepts a body below the limit`() {
+        val source = Buffer().write(ByteArray(LIMIT.toInt() - 1))
+        assertFalse(PlayerCipherConfigStore.exceedsLimit(source, LIMIT))
+    }
+
+    @Test
+    fun `accepts a body of exactly the limit`() {
+        val source = Buffer().write(ByteArray(LIMIT.toInt()))
+        assertFalse(PlayerCipherConfigStore.exceedsLimit(source, LIMIT))
+    }
+
+    @Test
+    fun `rejects a body one byte over the limit`() {
+        val source = Buffer().write(ByteArray(LIMIT.toInt() + 1))
+        // Allow buffered read-ahead while still failing if the complete oversized body is consumed.
+        assertTrue(PlayerCipherConfigStore.exceedsLimit(source, LIMIT))
+    }
+
+    @Test
+    fun `stops reading shortly after the limit`() {
+        val source = CountingSource(LIMIT + 128L * 1024)
+        assertTrue(PlayerCipherConfigStore.exceedsLimit(source.buffer(), LIMIT))
+        assertTrue(
+            "read ${source.bytesRead} bytes",
+            source.bytesRead < LIMIT + 64 * 1024,
+        )
+    }
+
+    /** Supplies [available] zero bytes and records how many of them were read. */
+    private class CountingSource(private val available: Long) : Source {
+        var bytesRead = 0L
+            private set
+
+        override fun read(sink: Buffer, byteCount: Long): Long {
+            val remaining = available - bytesRead
+            if (remaining <= 0L) return -1L
+            val count = minOf(byteCount, remaining)
+            sink.write(ByteArray(count.toInt()))
+            bytesRead += count
+            return count
+        }
+
+        override fun timeout(): Timeout = Timeout.NONE
+
+        override fun close() = Unit
+    }
+
+    private companion object {
+        const val LIMIT = 4L * 1024
+    }
+}


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Normal behavior remains unchanged.

--

`PlayerCipherConfigStore` loads cipher configurations from three sources: bundled assets,
the disk cache, and downloaded upstream files. Subsequently, since `sigFuncName` and `nClass` are
injected into the JavaScript executed by `CipherWebView`, all content contained in these fields becomes part of that
source. The types of that data are not checked at all, and the download size limit was applied
body had already been converted to a string.

- Limit `sigFuncName` and `nClass` to a single JavaScript identifier and skip
  mismatched entries. Since all three sources pass through the same function, this can be handled with a single check.
- Set the download limit based on the number of bytes read from the response body,
  rather than the number of characters in the resulting
  string. This ensures that bodies exceeding the size limit are rejected before being stored in memory. The limit value remains at its current
  level, and `ResponseBody.string()` continues to determine the character set.
- Add unit tests that cover the identifier rules, the existing `sig` parsing, and
  the fact that bodies exceeding the size limit are not read in their entirety.


### How it was tested

- `./gradlew :app:testCoreDebugUnitTest` passes, including the new tests.
-Xperia III, pass

### Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md)