### PR TITLE
Fix duplicate local artists and preserve library data on scan failures

### DIFF
--- a/app/src/main/java/androidx/documentfile/provider/TreeDocumentFileOt.kt
+++ b/app/src/main/java/androidx/documentfile/provider/TreeDocumentFileOt.kt
@@ -114,7 +114,14 @@ class TreeDocumentFileOt(
         return DocumentsContractApi19Ot.exists(context, _uri)
     }
 
-    override fun listFiles(): Array<DocumentFile> {
+    override fun listFiles(): Array<DocumentFile> = listFiles(suppressErrors = true)
+
+    /**
+     * Lists child documents without converting a provider query failure into a partial result.
+     */
+    fun listFilesOrThrow(): Array<DocumentFile> = listFiles(suppressErrors = false)
+
+    private fun listFiles(suppressErrors: Boolean): Array<DocumentFile> {
         val resolver = context.contentResolver
         val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(
             _uri, DocumentsContract.getDocumentId(_uri)
@@ -141,6 +148,7 @@ class TreeDocumentFileOt(
                 resultNames.add(documentName)
             }
         } catch (e: Exception) {
+            if (!suppressErrors) throw e
             Log.w(TAG, "Failed query: $e")
         } finally {
             closeQuietly(c)

--- a/app/src/main/java/io/github/yuuichi_s/astertune/MainActivityUtils.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/MainActivityUtils.kt
@@ -41,6 +41,7 @@ import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner
 import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner.Companion.destroyScanner
 import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner.Companion.scannerState
 import com.zionhuang.innertube.YouTube
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -194,6 +195,7 @@ suspend fun scanInit(
 
 
     // local media scan
+    var localScanFailed = false
     val perms = context.checkSelfPermission(MEDIA_PERMISSION_LEVEL)
     // Check if the permissions for local media access
     if (scannerState.value <= 0 && localLibEnable) {
@@ -208,10 +210,13 @@ suspend fun scanInit(
                 )
                 val uris = scanner.scanLocal(scanPaths, excludedScanPaths)
                 scanner.quickSync(database, uris, scannerSensitivity, strictExtensions, strictFilePaths)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
+                localScanFailed = true
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar(
-                        message = "${context.getString(R.string.scanner_scan_fail)}: ${e.message}",
+                        message = context.getString(R.string.scanner_scan_fail),
                         withDismissAction = true,
                         duration = SnackbarDuration.Short
                     )
@@ -227,7 +232,9 @@ suspend fun scanInit(
                 settings[LastLocalScanKey] = timeNow
             }
             playerConnection?.service?.initQueue()
-            Log.i(MAIN_TAG, "Local media and downloads scan completed")
+            if (!localScanFailed) {
+                Log.i(MAIN_TAG, "Local media and downloads scan completed")
+            }
         } else if (perms == PackageManager.PERMISSION_DENIED) {
             // Request the permission using the permission launcher
             (context as MainActivity).permissionLauncher.launch(MEDIA_PERMISSION_LEVEL)
@@ -237,13 +244,15 @@ suspend fun scanInit(
         Log.w(MAIN_TAG, "Cannot perform local media scan, scanner is in use")
     }
 
-    Log.i(MAIN_TAG, "Local media and downloads auto scan complete")
-    coroutineScope.launch {
-        snackbarHostState.showSnackbar(
-            message = context.getString(R.string.scanner_auto_end),
-            withDismissAction = true,
-            duration = SnackbarDuration.Short
-        )
+    if (!localScanFailed) {
+        Log.i(MAIN_TAG, "Local media and downloads auto scan complete")
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                message = context.getString(R.string.scanner_auto_end),
+                withDismissAction = true,
+                duration = SnackbarDuration.Short
+            )
+        }
     }
 
 }

--- a/app/src/main/java/io/github/yuuichi_s/astertune/db/DatabaseDao.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/db/DatabaseDao.kt
@@ -116,15 +116,18 @@ interface DatabaseDao : SongsDao, AlbumsDao, ArtistsDao, PlaylistsDao, QueueDao 
     )
     fun relatedSongs(songId: String): List<Song>
 
-    @Query("""
-        SELECT * FROM genre
-        WHERE genre.isLocal = 1
-        ORDER BY genre.title ASC
-    LIMIT :previewSize""")
-    fun allLocalGenresByName(previewSize: Int = Int.MAX_VALUE): List<GenreEntity>
+    /**
+     * All local genres in insertion order, so callers that merge duplicates can pick the oldest
+     * row of a group without another sort.
+     */
+    @Query("SELECT * FROM genre WHERE genre.isLocal = 1 ORDER BY genre.rowId ASC")
+    fun allLocalGenres(): List<GenreEntity>
 
     @Query("SELECT * FROM genre WHERE id = :id")
     fun genreById(id: String): GenreEntity?
+
+    @Query("UPDATE genre SET bookmarkedAt = :bookmarkedAt WHERE id = :genreId")
+    fun updateGenreBookmark(genreId: String, bookmarkedAt: LocalDateTime?)
 
     @Query("SELECT * FROM genre WHERE title = :name")
     fun genreByName(name: String): GenreEntity?
@@ -132,9 +135,17 @@ interface DatabaseDao : SongsDao, AlbumsDao, ArtistsDao, PlaylistsDao, QueueDao 
     @Query("SELECT * FROM genre WHERE isLocal = 1 AND title LIKE '%' || :query || '%' LIMIT :previewSize")
     fun localGenreByNameFuzzy(query: String, previewSize: Int = Int.MAX_VALUE): List<GenreEntity>
 
+    /**
+     * Relink songs of [oldId] to [newId]. Rows whose song is already linked to [newId] would
+     * violate the (songId, genreId) primary key, so they are left behind for [deleteSongGenreMap]
+     * to remove.
+     */
     @Transaction
-    @Query("UPDATE song_genre_map SET genreId = :newId WHERE genreId = :oldId")
+    @Query("UPDATE OR IGNORE song_genre_map SET genreId = :newId WHERE genreId = :oldId")
     fun updateSongGenreMap(oldId: String, newId: String)
+
+    @Query("DELETE FROM song_genre_map WHERE genreId = :genreId")
+    fun deleteSongGenreMap(genreId: String)
 
     @Query(
         """
@@ -168,7 +179,13 @@ interface DatabaseDao : SongsDao, AlbumsDao, ArtistsDao, PlaylistsDao, QueueDao 
     fun insert(mediaMetadata: MediaMetadata, block: (SongEntity) -> SongEntity = { it }) {
         if (insert(mediaMetadata.toSongEntity().let(block)) == -1L) return
         mediaMetadata.artists.forEachIndexed { index, artist ->
-            val artistId = artist.id ?: artistByName(artist.name)?.id ?: ArtistEntity.generateArtistId()
+            // Local songs arrive with a per-file artist id, so they match by name first. Each side
+            // only reuses a row of its own kind, keeping local and remote artists apart.
+            val artistId = if (artist.isLocal) {
+                localArtistByName(artist.name)?.id ?: artist.id ?: ArtistEntity.generateArtistId()
+            } else {
+                artist.id ?: remoteArtistByName(artist.name)?.id ?: ArtistEntity.generateArtistId()
+            }
             insert( // TODO: use upsert???
                 ArtistEntity(
                     id = artistId,

--- a/app/src/main/java/io/github/yuuichi_s/astertune/db/MusicDatabase.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/db/MusicDatabase.kt
@@ -11,6 +11,7 @@ import androidx.room.RenameColumn
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.withTransaction
 import androidx.room.migration.AutoMigrationSpec
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
@@ -64,6 +65,16 @@ class MusicDatabase(
             }
         }
     }
+
+    /**
+     * Run [block] in a transaction and suspend until it has been applied. Unlike [transaction],
+     * which only queues the work, the caller can rely on the write being visible afterwards and
+     * receives any exception it threw.
+     */
+    suspend fun <T> awaitTransaction(block: MusicDatabase.() -> T): T =
+        delegate.withTransaction {
+            block(this@MusicDatabase)
+        }
 
     fun close() = delegate.close()
 

--- a/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/AlbumsDao.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/AlbumsDao.kt
@@ -66,17 +66,48 @@ interface AlbumsDao : ArtistsDao {
     """)
     fun localAlbumsByNameFuzzy(query: String, previewSize: Int = Int.MAX_VALUE): List<AlbumEntity>
 
-    @Transaction
-    @Query("""
-        SELECT * FROM album
-        WHERE album.isLocal = 1
-        ORDER BY album.title ASC
-    LIMIT :previewSize""")
-    fun allLocalAlbumsByName(previewSize: Int = Int.MAX_VALUE): List<AlbumEntity>
+    /**
+     * All local albums in insertion order, so callers that merge duplicates can pick the oldest
+     * row of a group without another sort.
+     */
+    @Query("SELECT * FROM album WHERE album.isLocal = 1 ORDER BY album.rowId ASC")
+    fun allLocalAlbums(): List<AlbumEntity>
 
+    /**
+     * Relink songs of [oldId] to [newId]. Rows whose song is already linked to [newId] would
+     * violate the (songId, albumId) primary key, so they are left behind for [deleteSongAlbumMap]
+     * to remove.
+     */
     @Transaction
-    @Query("UPDATE song_album_map SET albumId = :newId WHERE albumId = :oldId")
+    @Query("UPDATE OR IGNORE song_album_map SET albumId = :newId WHERE albumId = :oldId")
     fun updateSongAlbumMap(oldId: String, newId: String)
+
+    @Query("DELETE FROM song_album_map WHERE albumId = :albumId")
+    fun deleteSongAlbumMap(albumId: String)
+
+    /**
+     * Recount songCount and duration of every local album from its linked songs, replacing the
+     * running totals kept by the song insert and scanner update paths.
+     */
+    @Query("""
+        UPDATE album
+        SET songCount = (
+                SELECT COUNT(*)
+                FROM song_album_map
+                    JOIN song ON song_album_map.songId = song.id
+                WHERE song_album_map.albumId = album.id
+                    AND song.inLibrary IS NOT NULL
+            ),
+            duration = (
+                SELECT COALESCE(SUM(song.duration), 0)
+                FROM song_album_map
+                    JOIN song ON song_album_map.songId = song.id
+                WHERE song_album_map.albumId = album.id
+                    AND song.inLibrary IS NOT NULL
+            )
+        WHERE album.isLocal = 1
+    """)
+    fun recountLocalAlbums()
 
     @Query(
         """
@@ -99,10 +130,33 @@ interface AlbumsDao : ArtistsDao {
         WHERE album.id = :albumId
         GROUP BY album.id
     """)
-    fun albumWithSongs(albumId: String): Flow<AlbumWithSongs?>
+    fun _albumWithSongs(albumId: String): Flow<AlbumWithSongs?>
 
+    /**
+     * Observes the album identified by [albumId] and its songs, omitting disabled songs for local
+     * albums.
+     */
+    fun albumWithSongs(albumId: String): Flow<AlbumWithSongs?> =
+        _albumWithSongs(albumId).map { album ->
+            if (album?.album?.isLocal == true) {
+                album.copy(songs = album.songs.filter { it.song.inLibrary != null })
+            } else {
+                album
+            }
+        }
+
+    /**
+     * Observes songs linked to [albumId], omitting disabled songs when the album is local.
+     */
     @Transaction
-    @Query("SELECT song.* FROM song JOIN song_album_map ON song.id = song_album_map.songId WHERE song_album_map.albumId = :albumId")
+    @Query("""
+        SELECT song.*
+        FROM song
+            JOIN song_album_map ON song.id = song_album_map.songId
+            JOIN album ON song_album_map.albumId = album.id
+        WHERE song_album_map.albumId = :albumId
+            AND (album.isLocal = 0 OR song.inLibrary IS NOT NULL)
+    """)
     fun albumSongs(albumId: String): Flow<List<Song>>
 
     @Transaction
@@ -292,8 +346,11 @@ interface AlbumsDao : ArtistsDao {
      * Set artistId
      */
     @Transaction
-    @Query("UPDATE album_artist_map SET artistId = :newId WHERE artistId = :oldId")
+    @Query("UPDATE OR IGNORE album_artist_map SET artistId = :newId WHERE artistId = :oldId")
     fun updateAlbumArtistMap(oldId: String, newId: String)
+
+    @Query("DELETE FROM album_artist_map WHERE artistId = :artistId")
+    fun deleteAlbumArtistMap(artistId: String)
 
     @Transaction
     @Query("DELETE FROM song_artist_map WHERE songId = :songID")

--- a/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/ArtistsDao.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/ArtistsDao.kt
@@ -52,6 +52,12 @@ interface ArtistsDao {
     @Query("SELECT * FROM artist WHERE name = :name")
     fun artistByName(name: String): ArtistEntity?
 
+    @Query("SELECT * FROM artist WHERE isLocal = 1 AND name = :name COLLATE NOCASE LIMIT 1")
+    fun localArtistByName(name: String): ArtistEntity?
+
+    @Query("SELECT * FROM artist WHERE isLocal = 0 AND name = :name LIMIT 1")
+    fun remoteArtistByName(name: String): ArtistEntity?
+
     @Query("SELECT * FROM artist WHERE isLocal = 1 AND name LIKE '%' || :name || '%'")
     fun localArtistsByNameFuzzy(name: String): List<ArtistEntity>
 
@@ -102,7 +108,11 @@ interface ArtistsDao {
     @Query("SELECT * FROM artist WHERE isLocal != 1")
     fun allRemoteArtists(): Flow<List<ArtistEntity>>
 
-    @Query("SELECT * FROM artist WHERE isLocal = 1")
+    /**
+     * All local artists in insertion order, so callers that merge duplicates can pick the oldest
+     * row of a group without another sort.
+     */
+    @Query("SELECT * FROM artist WHERE isLocal = 1 ORDER BY artist.rowId ASC")
     fun allLocalArtists(): List<ArtistEntity>
 
     @Query("""
@@ -180,21 +190,6 @@ interface ArtistsDao {
     fun artistsBookmarkedAsc() = artists(ArtistFilter.LIKED, ArtistSortType.CREATE_DATE, false)
     fun artistsLocalBookmarkedAsc() = artists(ArtistFilter.LIKED, ArtistSortType.CREATE_DATE, false, true)
 
-    @Transaction
-    @Query("""
-        SELECT 
-            artist.*,
-            COUNT(song.id) AS songCount,
-            SUM(CASE WHEN song.dateDownload IS NOT NULL THEN 1 ELSE 0 END) AS downloadCount
-        FROM artist
-            LEFT JOIN song_artist_map sam ON artist.id = sam.artistId
-            LEFT JOIN song ON sam.songId = song.id
-        WHERE artist.isLocal = 1
-        GROUP BY artist.id
-        ORDER BY artist.name ASC
-    """)
-    fun localArtistsByName(): List<Artist>
-
     /**
      * Representative artwork path for each local artist, preferring a local album cover and falling
      * back to a local song's embedded artwork. MIN() keeps the choice stable across rescans.
@@ -254,9 +249,17 @@ interface ArtistsDao {
         )
     }
 
+    /**
+     * Relink participations of [oldId] to [newId]. Rows whose song is already linked to [newId]
+     * would violate the (songId, artistId) primary key, so they are left behind for
+     * [deleteSongArtistMap] to remove.
+     */
     @Transaction
-    @Query("UPDATE song_artist_map SET artistId = :newId WHERE artistId = :oldId")
+    @Query("UPDATE OR IGNORE song_artist_map SET artistId = :newId WHERE artistId = :oldId")
     fun updateSongArtistMap(oldId: String, newId: String)
+
+    @Query("DELETE FROM song_artist_map WHERE artistId = :artistId")
+    fun deleteSongArtistMap(artistId: String)
     // endregion
 
     // region Deletes

--- a/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/SongsDao.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/db/daos/SongsDao.kt
@@ -404,7 +404,7 @@ interface SongsDao {
     @Query("UPDATE song SET liked = 0, likedDate = null WHERE id = :songId")
     fun removeLike(songId: String)
 
-    @Query("UPDATE song SET inLibrary = null WHERE localPath = null")
+    @Query("UPDATE song SET inLibrary = null WHERE localPath IS NULL AND isLocal = 1")
     fun disableInvalidLocalSongs()
 
     @Query("UPDATE song SET inLibrary = null, localPath = null WHERE id = :songId")

--- a/app/src/main/java/io/github/yuuichi_s/astertune/ui/screens/settings/fragments/LocalMediaSettingsFrag.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/ui/screens/settings/fragments/LocalMediaSettingsFrag.kt
@@ -92,6 +92,7 @@ import io.github.yuuichi_s.astertune.ui.utils.clearDtCache
 import io.github.yuuichi_s.astertune.utils.lmScannerCoroutine
 import io.github.yuuichi_s.astertune.utils.rememberEnumPreference
 import io.github.yuuichi_s.astertune.utils.rememberPreference
+import io.github.yuuichi_s.astertune.utils.reportException
 import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner.Companion.destroyScanner
 import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner.Companion.getScanner
 import io.github.yuuichi_s.astertune.utils.scanners.LocalMediaScanner.Companion.scannerProgressCurrent
@@ -102,6 +103,7 @@ import io.github.yuuichi_s.astertune.utils.scanners.ScannerAbortException
 import io.github.yuuichi_s.astertune.utils.scanners.absoluteFilePathFromUri
 import io.github.yuuichi_s.astertune.utils.scanners.stringFromUriList
 import io.github.yuuichi_s.astertune.utils.scanners.uriListFromString
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -238,6 +240,17 @@ fun ColumnScope.LocalScannerFrag() {
                                 withDismissAction = true,
                                 duration = SnackbarDuration.Short
                             )
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            scannerFailure = true
+                            reportException(e)
+
+                            snackbarHostState.showSnackbar(
+                                message = scanFailMessage,
+                                withDismissAction = true,
+                                duration = SnackbarDuration.Short
+                            )
                         } finally {
                             clearDtCache()
                             destroyScanner(SCANNER_OWNER_LM)
@@ -271,6 +284,17 @@ fun ColumnScope.LocalScannerFrag() {
 
                             snackbarHostState.showSnackbar(
                                 message = "$scanFailMessage: ${e.message}",
+                                withDismissAction = true,
+                                duration = SnackbarDuration.Short
+                            )
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            scannerFailure = true
+                            reportException(e)
+
+                            snackbarHostState.showSnackbar(
+                                message = scanFailMessage,
                                 withDismissAction = true,
                                 duration = SnackbarDuration.Short
                             )
@@ -476,12 +500,13 @@ fun ColumnScope.LocalScannerFrag() {
                 ActivityResultContracts.OpenDocumentTree()
             ) { uri ->
                 if (uri == null) return@rememberLauncherForActivityResult
-                if (tempScanPaths.any { it.toString() == uri.toString() }) return@rememberLauncherForActivityResult
 
                 val contentResolver = context.contentResolver
                 val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 contentResolver.takePersistableUriPermission(uri, takeFlags)
-                tempScanPaths.add(uri)
+                if (tempScanPaths.none { it.toString() == uri.toString() }) {
+                    tempScanPaths.add(uri)
+                }
             }
 
             Text(

--- a/app/src/main/java/io/github/yuuichi_s/astertune/utils/scanners/LocalMediaScanner.kt
+++ b/app/src/main/java/io/github/yuuichi_s/astertune/utils/scanners/LocalMediaScanner.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastMapNotNull
 import androidx.datastore.preferences.core.edit
 import androidx.documentfile.provider.DocumentFile
+import androidx.documentfile.provider.TreeDocumentFileOt
 import io.github.yuuichi_s.astertune.constants.SCANNER_DEBUG
 import io.github.yuuichi_s.astertune.constants.SYNC_SCANNER
 import io.github.yuuichi_s.astertune.constants.ScannerImpl
@@ -30,7 +31,6 @@ import io.github.yuuichi_s.astertune.constants.ScannerMatchCriteria
 import io.github.yuuichi_s.astertune.constants.scannerWhitelistExts
 import io.github.yuuichi_s.astertune.db.MusicDatabase
 import io.github.yuuichi_s.astertune.db.entities.AlbumEntity
-import io.github.yuuichi_s.astertune.db.entities.Artist
 import io.github.yuuichi_s.astertune.db.entities.ArtistEntity
 import io.github.yuuichi_s.astertune.db.entities.FormatEntity
 import io.github.yuuichi_s.astertune.db.entities.GenreEntity
@@ -53,6 +53,7 @@ import io.github.yuuichi_s.astertune.utils.reportException
 import com.zionhuang.innertube.YouTube
 import com.zionhuang.innertube.models.ArtistItem
 import com.zionhuang.innertube.models.SongItem
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -179,18 +180,23 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
     }
 
     /**
-     * Update the Database with local files
+     * Synchronizes scanned local songs with [database].
      *
-     * @param database
-     * @param newSongs
-     * @param matchStrength How lax should the scanner be
-     * @param strictFileNames Whether to consider file names
-     * @param refreshExisting Setting this this to true will updated existing songs
-     * with new information, else existing song's data will not be touched, regardless
-     * whether it was actually changed on disk
+     * Unmatched songs are inserted. A matched song keeps its database ID, download timestamp,
+     * Like state, and any non-null existing library-added timestamp. When [refreshExisting] is
+     * true, its scanned metadata, format, and artist, album, and genre mappings are refreshed.
+     * When false, it is updated only as needed to restore its local path or library availability.
      *
-     * Inserts a song if not found
-     * Updates a song information depending on if refreshExisting value
+     * Unless [noDisable] is true, duplicate local rows are consolidated, local songs absent from
+     * [newSongs] are disabled, and local album song counts and durations are recalculated.
+     *
+     * @param newSongs scanned local songs to synchronize
+     * @param matchStrength how closely a scanned song must match an existing song
+     * @param strictFileNames whether file names participate in matching
+     * @param strictFilePaths whether file paths must match
+     * @param refreshExisting whether to refresh metadata and relationship rows for matched songs
+     * @param noDisable whether to skip duplicate cleanup, missing-song disabling, and album
+     * recounting
      */
     suspend fun syncDB(
         database: MusicDatabase,
@@ -268,12 +274,19 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                     Log.v(TAG, "Found in database, updating song: ${song.song.title} rescan = $refreshExisting")
 
                 val oldSong = songMatch.first().song
-                val songToUpdate = song.song.song.copy(id = oldSong.id, localPath = song.song.song.localPath)
+                val songToUpdate = song.song.song.copy(
+                    id = oldSong.id,
+                    localPath = song.song.song.localPath,
+                    inLibrary = oldSong.inLibrary ?: song.song.song.inLibrary,
+                    dateDownload = oldSong.dateDownload,
+                    liked = oldSong.liked,
+                    likedDate = oldSong.likedDate,
+                )
 
                 // don't run if we will update these values in rescan anyways
                 // always ensure inLibrary and local path values are valid
                 if (!refreshExisting && (oldSong.inLibrary == null || oldSong.localPath == null)) {
-                    database.transaction {
+                    database.awaitTransaction {
                         update(songToUpdate)
 
                         // update format
@@ -298,7 +311,7 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                 var albumToDo: Pair<AlbumEntity?, AlbumEntity>? = null
 
                 // update artists and genre
-                database.transaction {
+                database.awaitTransaction {
                     // get any existing matches
                     song.song.artists.forEachIndexed { index, it ->
                         val dbQuery = localArtistsByNameFuzzy(it.name).sortedBy { item -> item.name.length }
@@ -374,7 +387,7 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                 if (SCANNER_DEBUG)
                     Log.v(TAG, "NOT found in database, adding song: ${song.song.title}")
 
-                database.transaction {
+                database.awaitTransaction {
                     insert(song.song.toMediaMetadata())
                     song.format?.let {
                         upsert(it.copy(id = song.song.id))
@@ -386,25 +399,33 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
         scannerProgressCurrent.value = scannerProgressTotal.value
         // do not delete songs from database automatically, we just disable them
         if (!noDisable) {
-            finalize(database)
+            reportUnmergedGroups(finalize(database))
             disableSongs(finalSongs.map { it.song }, database)
+            database.awaitTransaction { recountLocalAlbums() }
         }
         scannerState.value = 0
         Log.i(TAG, "------------ SYNC: Finished Local Library Sync ------------")
     }
 
     /**
-     * A faster scanner implementation that adds new songs to the database,
-     * and does not touch older songs entries (apart from removing
-     * inacessable songs from libaray).
+     * Scans paths in [newSongs] that are not already stored in [database].
      *
-     * No remote artist lookup is done
+     * [newSongs] represents the complete set of song URIs found by the current scan because it is
+     * also used to identify missing local songs. If a URI cannot be resolved to a file path, this
+     * function throws before updating the database.
      *
-     * WARNING: cachedDirectoryTree is not refreshed and may lead to inconsistencies.
-     * It is highly recommend to rebuild the tree after scanner operation
+     * Existing song metadata is not refreshed. After scanning new paths, this function:
      *
-     * @param newSongs List of songs. This is expecting a barebones DirectoryTree
-     * (only paths are necessary), thus you may use the output of refreshLocal().toList()
+     * - disables local songs whose paths are absent from the resolved input paths
+     * - removes duplicate song records and merges duplicate local artists, albums, and genres
+     * - recalculates local album song counts and durations
+     *
+     * Cleanup still runs when no new valid song is found. No remote artist lookup is performed.
+     *
+     * The cached directory tree is not refreshed, so callers displaying it should rebuild it after
+     * the scan.
+     *
+     * @param newSongs complete set of local-song URIs found by the current scan
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun quickSync(
@@ -425,7 +446,10 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
         // get list of all songs in db, then get songs unknown to the database
         // TODO: duplicate songs with different paths will cycle through paths, causing it to be synced instead of ignored...
         val allSongs = database.allLocalSongs().fastMapNotNull { it.song.localPath }.toSet()
-        val converted = newSongs.fastMapNotNull { fileFromUri(context, it)?.absolutePath }
+        val converted = newSongs.map { uri ->
+            fileFromUri(context, uri)?.absolutePath
+                ?: throw IOException("Could not resolve local file path: $uri")
+        }
         val delta = converted.minus(allSongs)
         Log.d(TAG, "Songs found: ${delta.size}")
         val mod = if (newSongs.size < 20) {
@@ -522,7 +546,8 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
         // we handle disabling songs here instead
         scannerState.value = 3
         disableSongsByPath(converted, database)
-        finalize(database)
+        reportUnmergedGroups(finalize(database))
+        database.awaitTransaction { recountLocalAlbums() }
 
         scannerState.value = 0
         Log.i(TAG, "------------ SYNC: Finished Quick (additive delta) Library Sync ------------")
@@ -530,16 +555,24 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
 
 
     /**
-     * Run a full scan and ful database update. This will update all song data in the
-     * database of all songs, and also disable inacessable songs
+     * Rescans [newSongs] and synchronizes local-song data with [database].
      *
-     * No remote artist lookup is done
+     * For a matched song, the scan refreshes its metadata, format, and artist, album, and genre
+     * relationships while preserving:
      *
-     * WARNING: cachedDirectoryTree is not refreshed and may lead to inconsistencies.
-     * It is highly recommend to rebuild the tree after scanner operation
+     * - its database ID
+     * - its download timestamp
+     * - its Like state
+     * - an existing non-null library-added timestamp
      *
-     * @param newSongs List of songs. This is expecting a barebones DirectoryTree
-     * (only paths are necessary), thus you may use the output of refreshLocal().toList()
+     * If at least one valid song is found, new songs are inserted, missing local songs are disabled,
+     * duplicate local rows are merged, and local album song counts and durations are recalculated.
+     * If no valid song is found, the database is left unchanged.
+     *
+     * No remote artist lookup is performed. The cached directory tree is not refreshed, so callers
+     * displaying it should rebuild it after the scan.
+     *
+     * @param newSongs local-song URIs to rescan
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun fullSync(
@@ -634,7 +667,7 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
         }
 
         scannerState.value = 0
-        Log.i(TAG, "------------ SYNC: Finished Quick (additive delta) Library Sync ------------")
+        Log.i(TAG, "------------ SYNC: Finished FULL Library Sync ------------")
     }
 
 
@@ -799,17 +832,18 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                     e.printStackTrace()
                 }
 
-                val artistList = ArrayList<ArtistEntity>()
-                val genresList = ArrayList<GenreEntity>()
+                val artistList = artist.split(ARTIST_SEPARATORS)
+                    .map { it.trim() }
+                    .filterNot { it.isBlank() }
+                    .distinctBy { it.lowercase() }
+                    .map { ArtistEntity(ArtistEntity.generateArtistId(), it, isLocal = true) }
 
-
-                artist.split(ARTIST_SEPARATORS).forEach { artistVal ->
-                    artistList.add(ArtistEntity(ArtistEntity.generateArtistId(), artistVal, isLocal = true))
-                }
-
-                genre?.split(ARTIST_SEPARATORS)?.forEach { genreVal ->
-                    genresList.add(GenreEntity(GenreEntity.generateGenreId(), genreVal, isLocal = true))
-                }
+                val genresList = genre?.split(ARTIST_SEPARATORS)
+                    ?.map { it.trim() }
+                    ?.filterNot { it.isBlank() }
+                    ?.distinctBy { it.lowercase() }
+                    ?.map { GenreEntity(GenreEntity.generateGenreId(), it, isLocal = true) }
+                    ?: emptyList()
                 val albumID = AlbumEntity.generateAlbumId()
                 val albumEntity = if (album != null) AlbumEntity(
                     id = albumID,
@@ -883,7 +917,8 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
         // we handle disabling songs here instead
         scannerState.value = 3
         disableSongsByPath(mediaStoreSongs.mapNotNull { it.song.song.localPath }, database)
-        finalize(database)
+        reportUnmergedGroups(finalize(database))
+        database.awaitTransaction { recountLocalAlbums() }
         scannerState.value = 0
 
 
@@ -908,7 +943,7 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
             if (newSongs.none { it == song.song.localPath }) {
                 if (SCANNER_DEBUG)
                     Log.v(TAG, "Disabling song ${song.song.localPath}")
-                database.transaction {
+                database.awaitTransaction {
                     disableLocalSong(song.song.id)
                 }
             }
@@ -941,9 +976,12 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
     }
 
     /**
-     * Remove inaccessible, and duplicate songs from the library
+     * Remove duplicate songs from the library and merge local artists, albums and genres that
+     * share a name.
+     *
+     * @return the number of duplicate groups that could not be merged
      */
-    private suspend fun finalize(database: MusicDatabase) {
+    private suspend fun finalize(database: MusicDatabase): Int {
         Log.i(TAG, "Start finalize (database cleanup job)")
 
         // remove duplicates
@@ -968,76 +1006,149 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
             }
         }
 
-        // remove duplicated local artists
-        val dbArtists: MutableList<Artist> = database.localArtistsByName().toMutableList()
-        while (dbArtists.isNotEmpty()) {
-            // gather same artists (precondition: artists are ordered by name
-            val tmp = ArrayList<Artist>()
-            val oldestArtist: Artist = dbArtists.removeAt(0)
-            tmp.add(oldestArtist)
-            while (dbArtists.isNotEmpty() && dbArtists.first().title == tmp.first().title) {
-                tmp.add(dbArtists.removeAt(0))
-            }
+        var failedGroups = 0
 
-            if (tmp.size > 1) {
-                try {
-                    // merge all duplicate artists into the oldest one
-                    tmp.removeAt(0)
-                    tmp.sortBy { it.artist.bookmarkedAt }
-                    tmp.forEach { swapArtists(it.artist, oldestArtist.artist, database) }
-                } catch (e: Exception) {
-                    reportException(e)
+        failedGroups += mergeDuplicates(
+            kind = "artists",
+            rows = database.allLocalArtists(),
+            id = { it.id },
+            name = { it.name },
+            bookmarkedAt = { it.bookmarkedAt }
+        ) { survivor, duplicates ->
+            database.awaitTransaction {
+                val target = artistById(survivor.id) ?: return@awaitTransaction false
+                val merged = duplicates.mapNotNull { artistById(it.id) }
+                merged.forEach { old ->
+                    updateSongArtistMap(old.id, target.id)
+                    updateAlbumArtistMap(old.id, target.id)
+                    deleteSongArtistMap(old.id)
+                    deleteAlbumArtistMap(old.id)
+                    safeDeleteArtist(old.id)
                 }
+                val bookmarkedAt = (merged + target).mapNotNull { it.bookmarkedAt }.minOrNull()
+                if (bookmarkedAt != target.bookmarkedAt) {
+                    update(target.copy(bookmarkedAt = bookmarkedAt))
+                }
+                true
             }
         }
 
-        // remove duplicated local albums
-        val dbAlbums: MutableList<AlbumEntity> = database.allLocalAlbumsByName().toMutableList()
-        while (dbAlbums.isNotEmpty()) {
-            // gather same artists (precondition: artists are ordered by name
-            val tmp = ArrayList<AlbumEntity>()
-            val oldestAlbum: AlbumEntity = dbAlbums.removeAt(0)
-            tmp.add(oldestAlbum)
-            while (dbAlbums.isNotEmpty() && dbAlbums.first().title == tmp.first().title) {
-                tmp.add(dbAlbums.removeAt(0))
-            }
-
-            if (tmp.size > 1) {
-                try {
-                    // merge all duplicate artists into the oldest one
-                    tmp.removeAt(0)
-                    tmp.sortBy { it.bookmarkedAt }
-                    tmp.forEach { swapAlbums(it, oldestAlbum, database) }
-                } catch (e: Exception) {
-                    reportException(e)
+        failedGroups += mergeDuplicates(
+            kind = "albums",
+            rows = database.allLocalAlbums(),
+            id = { it.id },
+            name = { it.title },
+            bookmarkedAt = { it.bookmarkedAt }
+        ) { survivor, duplicates ->
+            database.awaitTransaction {
+                val target = albumById(survivor.id) ?: return@awaitTransaction false
+                val merged = duplicates.mapNotNull { albumById(it.id) }
+                merged.forEach { old ->
+                    updateSongAlbumMap(old.id, target.id)
+                    deleteSongAlbumMap(old.id)
+                    safeDeleteAlbum(old.id)
                 }
+                val bookmarkedAt = (merged + target).mapNotNull { it.bookmarkedAt }.minOrNull()
+                if (bookmarkedAt != target.bookmarkedAt) {
+                    update(target.copy(bookmarkedAt = bookmarkedAt))
+                }
+                true
             }
         }
 
-        // remove duplicated genres
-        val dbGenres: MutableList<GenreEntity> = database.allLocalGenresByName().toMutableList()
-        while (dbGenres.isNotEmpty()) {
-            // gather same artists (precondition: artists are ordered by name
-            val tmp = ArrayList<GenreEntity>()
-            val oldestGenre: GenreEntity = dbGenres.removeAt(0)
-            tmp.add(oldestGenre)
-            while (dbGenres.isNotEmpty() && dbGenres.first().title == tmp.first().title) {
-                tmp.add(dbGenres.removeAt(0))
-            }
-
-            if (tmp.size > 1) {
-                try {
-                    // merge all duplicate artists into the oldest one
-                    tmp.removeAt(0)
-                    tmp.sortBy { it.bookmarkedAt }
-                    tmp.forEach { swapGenres(it, oldestGenre, database) }
-                } catch (e: Exception) {
-                    reportException(e)
+        failedGroups += mergeDuplicates(
+            kind = "genres",
+            rows = database.allLocalGenres(),
+            id = { it.id },
+            name = { it.title },
+            bookmarkedAt = { it.bookmarkedAt }
+        ) { survivor, duplicates ->
+            database.awaitTransaction {
+                val target = genreById(survivor.id) ?: return@awaitTransaction false
+                val merged = duplicates.mapNotNull { genreById(it.id) }
+                merged.forEach { old ->
+                    updateSongGenreMap(old.id, target.id)
+                    deleteSongGenreMap(old.id)
+                    safeDeleteGenre(old.id)
                 }
+                val bookmarkedAt = (merged + target).mapNotNull { it.bookmarkedAt }.minOrNull()
+                if (bookmarkedAt != target.bookmarkedAt) {
+                    updateGenreBookmark(target.id, bookmarkedAt)
+                }
+                true
             }
         }
 
         Log.i(TAG, "Finished finalize (duplicate removal) job")
+        return failedGroups
+    }
+
+    private fun reportUnmergedGroups(count: Int) {
+        if (count > 0) {
+            Log.w(TAG, "$count group(s) of duplicates were left in the library")
+        }
+    }
+
+    /**
+     * Merges rows whose names match when case is ignored.
+     *
+     * In each duplicate group, the row with the earliest bookmark timestamp survives. If none is
+     * bookmarked, the first row in the group survives. [merge] receives the surviving row and the
+     * remaining rows so it can update their mappings and remove the duplicates.
+     *
+     * Each group is passed to [merge] separately. A false result or a non-cancellation exception is
+     * counted as one failed group. Cancellation is rethrown; other exceptions are logged, and
+     * processing continues with the next group.
+     *
+     * @param rows candidate rows in insertion order
+     * @return number of groups that were not merged
+     */
+    private suspend fun <T> mergeDuplicates(
+        kind: String,
+        rows: List<T>,
+        id: (T) -> String,
+        name: (T) -> String,
+        bookmarkedAt: (T) -> LocalDateTime?,
+        merge: suspend (survivor: T, duplicates: List<T>) -> Boolean,
+    ): Int {
+        val groups = rows.groupBy { name(it).lowercase() }.values.filter { it.size > 1 }
+        Log.d(TAG, "Start finalize (duplicate $kind) job. Number of groups: ${groups.size}")
+
+        var merged = 0
+        var failed = 0
+        groups.forEach { group ->
+            val survivor = group.filter { bookmarkedAt(it) != null }.minByOrNull { bookmarkedAt(it)!! }
+                ?: group.first()
+            val duplicates = group.filterNot { it === survivor }
+            val groupName = name(survivor).lineSequence().joinToString(" ")
+            try {
+                if (merge(survivor, duplicates)) {
+                    merged++
+                } else {
+                    failed++
+                    Log.w(
+                        TAG,
+                        "Duplicate merge skipped: kind=$kind, name=$groupName, rows=${group.size}, " +
+                                "survivorId=${id(survivor)}, duplicateIds=${duplicates.joinToString { id(it) }}, " +
+                                "reason=survivor missing"
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                failed++
+                val exception = "${e.javaClass.simpleName}: ${e.message}".lineSequence().joinToString(" ")
+                Log.e(
+                    TAG,
+                    "Duplicate merge failed: kind=$kind, name=$groupName, rows=${group.size}, " +
+                            "survivorId=${id(survivor)}, duplicateIds=${duplicates.joinToString { id(it) }}, " +
+                            "exception=$exception"
+                )
+                reportException(e)
+            }
+        }
+        Log.i(TAG, "Duplicate merge result: kind=$kind, groups=${groups.size}, merged=$merged, failed=$failed")
+        return failed
     }
 
 
@@ -1138,7 +1249,7 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                     val file = documentFileFromUri(context, path)
                     if (file != null) {
                         val songsHere = ArrayList<DocumentFile>()
-                        scanDfRecursive(file, songsHere) {
+                        scanDfRecursive(file, songsHere, failOnListingError = true) {
                             // Allow: audio mime, or certain audio exts
                             // Disallow: x-mpegurl (m3u)
                             val mime = it.type ?: return@scanDfRecursive false
@@ -1173,14 +1284,18 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
             dir: DocumentFile,
             result: ArrayList<DocumentFile>,
             scanHidden: Boolean = false,
+            failOnListingError: Boolean = false,
             validator: ((DocumentFile) -> Boolean)? = null
         ): DocumentFile? {
-            val files = dir.listFiles()
+            val files = listFiles(dir, failOnListingError)
             for (file in files) {
                 if (!scanHidden && file.name?.startsWith(".") == true) continue
-                if (file.isDirectory && (scanHidden || !file.listFiles().any { it.name == ".nomedia" })) {
+                if (
+                    file.isDirectory &&
+                    (scanHidden || !listFiles(file, failOnListingError).any { it.name == ".nomedia" })
+                ) {
                     // look into subdirs
-                    scanDfRecursive(file, result, scanHidden, validator)
+                    scanDfRecursive(file, result, scanHidden, failOnListingError, validator)
                 } else {
                     // add if file matches
                     if (validator == null || validator(file)) {
@@ -1193,6 +1308,14 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
                 }
             }
             return null
+        }
+
+        private fun listFiles(dir: DocumentFile, failOnListingError: Boolean): Array<DocumentFile> {
+            return if (failOnListingError) {
+                (dir as TreeDocumentFileOt).listFilesOrThrow()
+            } else {
+                dir.listFiles()
+            }
         }
 
         /**
@@ -1406,70 +1529,6 @@ class LocalMediaScanner(context: Context, scannerImpl: ScannerImpl) {
             }
 
             return ytmResult
-        }
-
-        /**
-         * Swap all participation(s) with old artist to use new artist
-         *
-         * p.s. This is here instead of DatabaseDao because it won't compile there because
-         * "oooga boooga error in generated code"
-         */
-        fun swapArtists(old: ArtistEntity, new: ArtistEntity, database: MusicDatabase) {
-            database.transaction {
-                if (artistById(old.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent old artist in database with id: ${old.id}"))
-                    return@transaction
-                }
-                if (artistById(new.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent new artist in database with id: ${new.id}"))
-                    return@transaction
-                }
-
-                // update participation(s)
-                updateSongArtistMap(old.id, new.id)
-                updateAlbumArtistMap(old.id, new.id)
-
-                // nuke old artist
-                safeDeleteArtist(old.id)
-            }
-        }
-
-        fun swapAlbums(old: AlbumEntity, new: AlbumEntity, database: MusicDatabase) {
-            database.transaction {
-                if (albumById(old.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent old album in database with id: ${old.id}"))
-                    return@transaction
-                }
-                if (albumById(new.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent new album in database with id: ${new.id}"))
-                    return@transaction
-                }
-
-                // update participation(s)
-                updateSongAlbumMap(old.id, new.id)
-
-                // nuke old artist
-                safeDeleteAlbum(old.id)
-            }
-        }
-
-        fun swapGenres(old: GenreEntity, new: GenreEntity, database: MusicDatabase) {
-            database.transaction {
-                if (genreById(old.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent old album in database with id: ${old.id}"))
-                    return@transaction
-                }
-                if (genreById(new.id) == null) {
-                    reportException(Exception("Attempting to swap with non-existent new album in database with id: ${new.id}"))
-                    return@transaction
-                }
-
-                // update participation(s)
-                updateSongGenreMap(old.id, new.id)
-
-                // nuke old genre
-                safeDeleteGenre(old.id)
-            }
         }
     }
 }


### PR DESCRIPTION
### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Local media rescans could create duplicate artists for the same artist name. A rescan could also continue with local-library updates when a selected folder could not be read, and successful rescans did not consistently retain existing song state.

This PR updates the local media scan flow to:

- Reuse existing same-name local artists and consolidate existing duplicate local artists, albums, and genres while preserving song relationships and bookmark timestamps.
- Treat an unreadable selected folder as a scan failure before modifying the local library, reacquire persisted folder access when the folder is reselected, and show a generic failure message while retaining exception details in logs.
- Update existing local song records without changing their IDs, library and download timestamps, or Like state.
- Recalculate local album totals after missing songs are disabled and exclude disabled songs from local album results.

Verification:

- Built and installed the Full Debug variant with `./gradlew installFullDebug`.
- Confirmed on a device that an unreadable selected folder aborts the scan without removing existing local songs.
- Confirmed that reselecting the folder allows a full rescan to complete, consolidates duplicate artists, updates album totals, and retains Like state.
- Compared the database before and after the rescan and confirmed that local song IDs, paths, library state, relationships, and album totals remain consistent.
- Confirmed that `git diff --check` reports no errors.
- The simplified failure message was not reproduced after folder access had been restored. Its code path and the successful build were verified.

### Before/After Screenshots/Screen Record

- Before: Not captured. During device verification, the failure notification included internal Android exception details.
- After: Not captured because folder access had already been restored. The failure state was not intentionally recreated solely for a screenshot.

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/yuuichi-s/AsterTune/blob/dev/CONTRIBUTING.md)
